### PR TITLE
Fixed bug with keys being called on None

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -627,8 +627,8 @@ class Map(BaseContainerColumn):
         if isinstance(val, self.Quoter): val = val.value
         if isinstance(prev, self.Quoter): prev = prev.value
 
-        old_keys = set(prev.keys())
-        new_keys = set(val.keys())
+        old_keys = set(prev.keys()) if prev else set()
+        new_keys = set(val.keys()) if val else set()
         del_keys = old_keys - new_keys
 
         del_statements = []


### PR DESCRIPTION
If I try to use the Map column type in my models, save() fails because, get_del_statement is not checking to see if prev exists before calling the key function on it.

This patch fixes it and save() works as expected.
