### PR TITLE
Fixed issue where BaseModel as dict was not converting values to native Python collection types

### DIFF
--- a/cqlengine/models.py
+++ b/cqlengine/models.py
@@ -117,7 +117,14 @@ class BaseModel(object):
         """ Returns a map of column names to cleaned values """
         values = self._dynamic_columns or {}
         for name, col in self._columns.items():
-            values[name] = col.to_database(getattr(self, name, None))
+            tmp = col.to_database(getattr(self, name, None))
+            types = (columns.List, columns.Map, columns.Set)
+            if isinstance(col, types[0:2]):
+                values[name] = tmp.value
+            elif isinstance(col, types[2]):
+                values[name] = list(tmp.value)
+            else:
+                values[name] = tmp
         return values
 
     @classmethod


### PR DESCRIPTION
I ran into a problem when I tried to do json.dumps on an instance of a cqlengine model. Upon investigating I found that one of the fields was a Map. And since json serializer does not know about cqlengine types it would fail.

This patch works if it makes sense for the as_dict in BaseModel to convert all cqlengine Collection types in the dictionary to native Python types.

If there's a good reason to keep the dictionary values as cqlengine Collection types, then the application can use similar code within its model (e.g below).

I'd like to know the right way to fix this. Please let me know. Thanks.

```
def as_json(self):
    values = self._dynamic_columns or {}
    for name, col in self._columns.items():
        tmp = col.to_database(getattr(self, name, None))
        if isinstance(tmp, Map.Quoter):
            values[name] = tmp.value
        else:
            values[name] = tmp

    return json.dumps(values)
```
