### PR TITLE
Log the CQL statements at DEBUG level.

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -326,6 +326,9 @@ class ContainerQuoter(object):
     def __str__(self):
         raise NotImplementedError
 
+    def __repr__(self):
+        return self.__str__()
+
 class BaseContainerColumn(Column):
     """
     Base Container type

--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -7,11 +7,13 @@ import Queue
 import random
 
 import cql
+import logging
 
 from cqlengine.exceptions import CQLEngineException
 
 from thrift.transport.TTransport import TTransportException
 
+LOG = logging.getLogger('cqlengine.cql')
 
 class CQLConnectionError(CQLEngineException): pass
 
@@ -167,6 +169,7 @@ class connection_manager(object):
 
         for i in range(len(_hosts)):
             try:
+                LOG.debug('{} {}'.format(query, repr(params)))
                 self.cur = self.con.cursor()
                 self.cur.execute(query, params)
                 return self.cur


### PR DESCRIPTION
This logs the CQL statements emitted by cqlengine in the
`cqlengine.cql` logger at DEBUG level. For debugging purposes you can
enable that logger to help work out problems with your queries.

The logger is not enabled by default by `cqlengine`.
