### PR TITLE
Allow `datetime.date` values with `columns.DateTime`.

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -183,6 +183,7 @@ class Text(Column):
                 raise ValidationError('{} is shorter than {} characters'.format(self.column_name, self.min_length))
         return value
 
+
 class Integer(Column):
     db_type = 'int'
 
@@ -200,20 +201,27 @@ class Integer(Column):
     def to_database(self, value):
         return self.validate(value)
 
+
 class DateTime(Column):
     db_type = 'timestamp'
+
     def __init__(self, **kwargs):
         super(DateTime, self).__init__(**kwargs)
 
     def to_python(self, value):
         if isinstance(value, datetime):
             return value
+        elif isinstance(value, date):
+            return datetime(*(value.timetuple()[:6]))
         return datetime.utcfromtimestamp(value)
 
     def to_database(self, value):
         value = super(DateTime, self).to_database(value)
         if not isinstance(value, datetime):
-            raise ValidationError("'{}' is not a datetime object".format(value))
+            if isinstance(value, date):
+                value = datetime(value.year, value.month, value.day)
+            else:
+                raise ValidationError("'{}' is not a datetime object".format(value))
         epoch = datetime(1970, 1, 1, tzinfo=value.tzinfo)
         offset = 0
         if epoch.tzinfo:
@@ -325,6 +333,7 @@ class ContainerQuoter(object):
 
     def __str__(self):
         raise NotImplementedError
+
 
 class BaseContainerColumn(Column):
     """

--- a/cqlengine/tests/columns/test_validation.py
+++ b/cqlengine/tests/columns/test_validation.py
@@ -55,6 +55,12 @@ class TestDatetime(BaseCassEngTestCase):
         dt2 = self.DatetimeTest.objects(test_id=0).first()
         assert dt2.created_at.timetuple()[:6] == (now + timedelta(hours=1)).timetuple()[:6]
 
+    def test_datetime_date_support(self):
+        today = date.today()
+        self.DatetimeTest.objects.create(test_id=0, created_at=today)
+        dt2 = self.DatetimeTest.objects(test_id=0).first()
+        assert dt2.created_at.isoformat() == datetime(today.year, today.month, today.day).isoformat()
+
 
 class TestDate(BaseCassEngTestCase):
     class DateTest(Model):


### PR DESCRIPTION
Adds support for setting a `datetime.date` value to a `DateTime`
column. The value will be transparently converted to a
`datetime.datetime` with the time components set to zero.
