### PR TITLE
Restore CQL query logging at DEBUG level.

### DIFF
--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -141,6 +141,7 @@ class ConnectionPool(object):
             con = self.get()
             cur = con.cursor()
             cur.execute(query, params)
+            LOG.debug('{} {}'.format(query, repr(params)))
             self.put(con)
             return cur
         except cql.ProgrammingError as ex:


### PR DESCRIPTION
This got removed at some point during the connection refactoring I think.
