### PR TITLE
Make ValueQuoter objects equal if their repr() are equal.

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -65,6 +65,11 @@ class ValueQuoter(object):
     def __repr__(self):
         return self.__str__()
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return repr(self) == repr(other)
+        return False
+
 
 class Column(object):
 

--- a/cqlengine/tests/columns/test_value_io.py
+++ b/cqlengine/tests/columns/test_value_io.py
@@ -7,7 +7,10 @@ from cqlengine.tests.base import BaseCassEngTestCase
 from cqlengine.management import create_table
 from cqlengine.management import delete_table
 from cqlengine.models import Model
+from cqlengine.columns import ValueQuoter
 from cqlengine import columns
+import unittest
+
 
 class BaseColumnIOTest(BaseCassEngTestCase):
     """
@@ -145,3 +148,11 @@ class TestDecimalIO(BaseColumnIOTest):
 
     def comparator_converter(self, val):
         return Decimal(val)
+
+class TestQuoter(unittest.TestCase):
+
+    def test_equals(self):
+        assert ValueQuoter(False) == ValueQuoter(False)
+        assert ValueQuoter(1) == ValueQuoter(1)
+        assert ValueQuoter("foo") == ValueQuoter("foo")
+        assert ValueQuoter(1.55) == ValueQuoter(1.55)


### PR DESCRIPTION
This makes model instances which have quoted values to equal in an
intuitive manner.
