### PR TITLE
added a retry until no servers can be contacted

### DIFF
--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -151,21 +151,23 @@ class ConnectionPool(object):
         raise CQLConnectionError("Could not connect to any server in cluster")
 
     def execute(self, query, params):
-        try:
-            con = self.get()
-            cur = con.cursor()
-            cur.execute(query, params)
-            columns = [i[0] for i in cur.description or []]
-            results = [RowResult(r) for r in cur.fetchall()]
-            LOG.debug('{} {}'.format(query, repr(params)))
-            self.put(con)
-            return QueryResult(columns, results)
-        except cql.ProgrammingError as ex:
-            raise CQLEngineException(unicode(ex))
-        except TTransportException:
-            pass
+        while True:
+            try:
+                con = self.get()
+                cur = con.cursor()
+                cur.execute(query, params)
+                columns = [i[0] for i in cur.description or []]
+                results = [RowResult(r) for r in cur.fetchall()]
+                LOG.debug('{} {}'.format(query, repr(params)))
+                self.put(con)
+                return QueryResult(columns, results)
+            except CQLConnectionError as ex:
+                raise CQLEngineException("Could not execute query against the cluster")
+            except cql.ProgrammingError as ex:
+                raise CQLEngineException(unicode(ex))
+            except TTransportException:
+                raise CQLEngineException("Could not execute query against the cluster")
 
-        raise CQLEngineException("Could not execute query against the cluster")
 
 
 def execute(query, params={}):


### PR DESCRIPTION
when we execute_query, if the connection is down, it just shits the bed.  if we retry till no connections are available, we can either:
- return an actual result
- exhaust the pool 

either way, if any of the servers are up and we're using < ALL, we should be able to give back a result
