### PR TITLE
Ability To Specify Connection Timeouts

### DIFF
--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -67,7 +67,7 @@ def setup(
     :type default_keyspace: str
     :param consistency: The global consistency level
     :type consistency: str
-    :param timeout: The connection timeout in milliseconds
+    :param timeout: The connection timeout in seconds
     :type timeout: int or long
 
     """


### PR DESCRIPTION
### The Problem

At this time it is impossible to set a socket-level timeout in cqlengine. This can produce problems when attempting to connect to a non-existent or downed node. By default the Python `socket._GLOBAL_DEFAULT_TIMEOUT` is used and this tends can be an extraordinarily long time for a database socket to wait.
### The Solution

The python `cql.connect` method takes an optional transport object. We are now manually constructing a `thrift.transport.TTransport.TFramedTransport` object so that we can set the timeout on the underlying socket object as this option is not provided by the cql library itself.

One transport is created per open connection and closed by `cql` once the connection is closed or the object is cleaned up by garbage collection.
