### PR TITLE
Add more informative exception message

### DIFF
--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -216,7 +216,9 @@ class ConnectionPool(object):
                 self.put(con)
                 return QueryResult(columns, results)
             except CQLConnectionError as ex:
-                raise CQLEngineException("Could not execute query against the cluster")
+                message = ("Could not execute query against the cluster. "
+                           "Failed with error '{}'".format(unicode(ex)))
+                raise CQLEngineException(message)
             except cql.ProgrammingError as ex:
                 raise CQLEngineException(unicode(ex))
             except TTransportException:


### PR DESCRIPTION
### The Problem

Right now cqlengine is swallowing the contents of the CQLConnectionError exception. In testing I am seeing several errors involving this and it is hard to debug further without more information.
### The Solution

Include the message contents of the exception in the error message
