### PR TITLE
add BigInt column

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -252,6 +252,10 @@ class Integer(Column):
         return self.validate(value)
 
 
+class BigInt(Integer):
+    db_type = 'bigint'
+
+
 class VarInt(Column):
     db_type = 'varint'
 

--- a/cqlengine/tests/columns/test_validation.py
+++ b/cqlengine/tests/columns/test_validation.py
@@ -15,6 +15,7 @@ from cqlengine.columns import Bytes
 from cqlengine.columns import Ascii
 from cqlengine.columns import Text
 from cqlengine.columns import Integer
+from cqlengine.columns import BigInt
 from cqlengine.columns import VarInt
 from cqlengine.columns import DateTime
 from cqlengine.columns import Date
@@ -178,6 +179,16 @@ class TestInteger(BaseCassEngTestCase):
     def test_default_zero_fields_validate(self):
         """ Tests that integer columns with a default value of 0 validate """
         it = self.IntegerTest()
+        it.validate()
+
+class TestBigInt(BaseCassEngTestCase):
+    class BigIntTest(Model):
+        test_id = UUID(primary_key=True, default=lambda:uuid4())
+        value   = BigInt(default=0, required=True)
+
+    def test_default_zero_fields_validate(self):
+        """ Tests that bigint columns with a default value of 0 validate """
+        it = self.BigIntTest()
         it.validate()
 
 class TestText(BaseCassEngTestCase):

--- a/cqlengine/tests/columns/test_value_io.py
+++ b/cqlengine/tests/columns/test_value_io.py
@@ -95,6 +95,12 @@ class TestInteger(BaseColumnIOTest):
     pkey_val = 5
     data_val = 6
 
+class TestBigInt(BaseColumnIOTest):
+
+    column = columns.BigInt
+    pkey_val = 6
+    data_val = pow(2, 63) - 1
+
 class TestDateTime(BaseColumnIOTest):
 
     column = columns.DateTime

--- a/docs/topics/columns.rst
+++ b/docs/topics/columns.rst
@@ -38,9 +38,15 @@ Columns
 
 .. class:: Integer()
 
-    Stores an integer value ::
+    Stores a 32-bit signed integer value ::
 
         columns.Integer()
+
+.. class:: BigInt()
+
+    Stores a 64-bit signed long value ::
+
+        columns.BigInt()
 
 .. class:: VarInt()
 


### PR DESCRIPTION
BigInt column.
Inherits from Integer column.

Addresses this issue
https://github.com/cqlengine/cqlengine/issues/81

Doc changes now cite Integer as "32-bit signed integer" and BigInt as "64-bit signed long" per CQL docs
http://www.datastax.com/documentation/cql/3.0/webhelp/index.html#cql/cql_reference/cql_data_types_c.html
