### PR TITLE
Allow use of timezone aware datetimes in {Max,Min}TimeUUID

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -328,11 +328,9 @@ class DateTime(Column):
             else:
                 raise ValidationError("'{}' is not a datetime object".format(value))
         epoch = datetime(1970, 1, 1, tzinfo=value.tzinfo)
-        offset = 0
-        if epoch.tzinfo:
-            offset_delta = epoch.tzinfo.utcoffset(epoch)
-            offset = offset_delta.days*24*3600 + offset_delta.seconds
-        return long(((value  - epoch).total_seconds() - offset) * 1000)
+        offset = epoch.tzinfo.utcoffset(epoch).total_seconds() if epoch.tzinfo else 0
+
+        return long(((value - epoch).total_seconds() - offset) * 1000)
 
 
 class Date(Column):
@@ -402,12 +400,7 @@ class TimeUUID(UUID):
         global _last_timestamp
 
         epoch = datetime(1970, 1, 1, tzinfo=dt.tzinfo)
-
-        offset = 0
-        if epoch.tzinfo:
-            offset_delta = epoch.tzinfo.utcoffset(epoch)
-            offset = offset_delta.days*24*3600 + offset_delta.seconds
-
+        offset = epoch.tzinfo.utcoffset(epoch).total_seconds() if epoch.tzinfo else 0
         timestamp = (dt  - epoch).total_seconds() - offset
 
         node = None

--- a/cqlengine/functions.py
+++ b/cqlengine/functions.py
@@ -54,8 +54,10 @@ class MinTimeUUID(BaseQueryFunction):
         super(MinTimeUUID, self).__init__(value)
 
     def get_value(self):
-        epoch = datetime(1970, 1, 1)
-        return long((self.value - epoch).total_seconds() * 1000)
+        epoch = datetime(1970, 1, 1, tzinfo=self.value.tzinfo)
+        offset = epoch.tzinfo.utcoffset(epoch).total_seconds() if epoch.tzinfo else 0
+
+        return long(((self.value - epoch).total_seconds() - offset) * 1000)
 
     def get_dict(self, column):
         return {self.identifier: self.get_value()}
@@ -79,8 +81,10 @@ class MaxTimeUUID(BaseQueryFunction):
         super(MaxTimeUUID, self).__init__(value)
 
     def get_value(self):
-        epoch = datetime(1970, 1, 1)
-        return long((self.value - epoch).total_seconds() * 1000)
+        epoch = datetime(1970, 1, 1, tzinfo=self.value.tzinfo)
+        offset = epoch.tzinfo.utcoffset(epoch).total_seconds() if epoch.tzinfo else 0
+
+        return long(((self.value - epoch).total_seconds() - offset) * 1000)
 
     def get_dict(self, column):
         return {self.identifier: self.get_value()}


### PR DESCRIPTION
Convert the given timezone aware datetimes to UTC in a similar manner
as the DateTime column type does instead of resulting in an error.
