### PR TITLE
Changed List column's default to be list and not set

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -647,7 +647,7 @@ class List(BaseContainerColumn):
         def __nonzero__(self):
             return bool(self.value)
 
-    def __init__(self, value_type, default=set, **kwargs):
+    def __init__(self, value_type, default=list, **kwargs):
         return super(List, self).__init__(value_type=value_type, default=default, **kwargs)
 
     def validate(self, value):


### PR DESCRIPTION
Hi,
I noticed that the default-default type of the List column was set, and could not find a reason for it, so I guessed it was a leftover from copying code from the Set column :)

anyway, here's a fix to this.
