### PR TITLE
fix ttl in update statement

### DIFF
--- a/cqlengine/statements.py
+++ b/cqlengine/statements.py
@@ -582,14 +582,15 @@ class UpdateStatement(AssignmentStatement):
 
     def __unicode__(self):
         qs = ['UPDATE', self.table]
+
+        if self.ttl:
+            qs += ["USING TTL {}".format(self.ttl)]
+
         qs += ['SET']
         qs += [', '.join([unicode(c) for c in self.assignments])]
 
         if self.where_clauses:
             qs += [self._where]
-
-        if self.ttl:
-            qs += ["USING TTL {}".format(self.ttl)]
 
         return ' '.join(qs)
 


### PR DESCRIPTION
In CQL3 the USING clause in UPDATE statements come before the SET clause.
http://cassandra.apache.org/doc/cql3/CQL.html#updateStmt
