### PR TITLE
Fix logic determining if compaction options need syncing

### DIFF
--- a/cqlengine/models.py
+++ b/cqlengine/models.py
@@ -214,7 +214,7 @@ class BaseModel(object):
     # compaction options
     __compaction__ = None
     __compaction_tombstone_compaction_interval__ = None
-    __compaction_tombstone_threshold = None
+    __compaction_tombstone_threshold__ = None
 
     # compaction - size tiered options
     __compaction_bucket_high__ = None


### PR DESCRIPTION
The compaction_strategy_options as received from the
`system.schema_columnfamilies` table are all string valued and
comparison to typed values (ints, floats) as defined in models results
in sync_table() issuning ALTER TABLE statements redundantly even if
there were no changes to compaction options.

This patch casts the values defined in models to strings to ensure they
compare equal as needed.

Additionally, this patch normalizes handling of the `min_threshold` and
`max_threshold` options for SizeTieredCompactionStrategy which exist
outside the `compaction_strategy_options` mapping and have different
names in the `system.schema_columnfamilies` table compared to the CQL
options.

A typo in the `BaseModel.__compaction_tombstone_threshold__` option is
also fixed.

The failing tests also fail on the current master.
