### PR TITLE
bugfix: connection.setup - cast port to int

### DIFF
--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -85,11 +85,16 @@ def setup(
         host = host.strip()
         host = host.split(':')
         if len(host) == 1:
-            _hosts.append(Host(host[0], 9160))
+            port = 9160
         elif len(host) == 2:
-            _hosts.append(Host(*host))
+            try:
+                port = int(host[1])
+            except ValueError:
+                raise CQLConnectionError("Can't parse {}".format(''.join(host)))
         else:
             raise CQLConnectionError("Can't parse {}".format(''.join(host)))
+
+        _hosts.append(Host(host[0], port))
 
     if not _hosts:
         raise CQLConnectionError("At least one host required")

--- a/cqlengine/tests/connections/test_connection_setup.py
+++ b/cqlengine/tests/connections/test_connection_setup.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+from mock import MagicMock, patch, Mock
+
+from cqlengine.connection import setup, CQLConnectionError, Host
+
+
+class OperationalErrorLoggingTest(TestCase):
+    @patch('cqlengine.connection.ConnectionPool', return_value=None, autospec=True)
+    def test_setup_hosts(self, PatchedConnectionPool):
+        with self.assertRaises(CQLConnectionError):
+            setup(hosts=['localhost:abcd'])
+            self.assertEqual(len(PatchedConnectionPool.mock_calls), 0)
+
+        with self.assertRaises(CQLConnectionError):
+            setup(hosts=['localhost:9160:abcd'])
+            self.assertEqual(len(PatchedConnectionPool.mock_calls), 0)
+
+        setup(hosts=['localhost:9161', 'remotehost'])
+        self.assertEqual(len(PatchedConnectionPool.mock_calls), 1)
+        self.assertEqual(PatchedConnectionPool.call_args[0][0], [Host('localhost', 9161), Host('remotehost', 9160)])


### PR DESCRIPTION
I encountered this error in my project logs, so I wrote this fix.

DEBUG in connection._create_connection:202: Could not establish connection to SOMEHOST:9161 (TypeError('%d format: a number is required, not str',))
