### PR TITLE
fix (rare) race condition in ConnectionPool.get()

### DIFF
--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -142,9 +142,9 @@ class ConnectionPool(object):
         a new one.
         """
         try:
-            # get with blocking=False (default) returns an item if one
+            # get with block=False returns an item if one
             # is immediately available, else raises the Empty exception
-            return self._queue.get()
+            return self._queue.get(block=False)
         except queue.Empty:
             try:
                 return self._create_connection()


### PR DESCRIPTION
Before this fix, in the scenario of 2 threads (t1, t2) issuing ConnectionPool.get() and 1 connection is in the queue, the following could have happened:

t1> self._queue.empty()
False
t2> self._queue.empty()
False
t1> return self._queue.get()
gets a connection
t2> return self._queue.get()
**raise queue.Empty**
