### PR TITLE
Compare keys against other instead of self in __eq__

### DIFF
--- a/cqlengine/models.py
+++ b/cqlengine/models.py
@@ -376,7 +376,7 @@ class BaseModel(object):
 
         # check attribute keys
         keys = set(self._columns.keys())
-        other_keys = set(self._columns.keys())
+        other_keys = set(other._columns.keys())
         if keys != other_keys:
             return False
 


### PR DESCRIPTION
The equivalence function in BaseModel was comparing an item's keys against itself instead of other. Quick bugfix.
