### PR TITLE
fixed camelCase naming for container column names

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -537,7 +537,7 @@ class BaseContainerColumn(Column):
         Returns a column definition for CQL table definition
         """
         db_type = self.db_type.format(self.value_type.db_type)
-        return '{} {}'.format(self.db_field_name, db_type)
+        return '{} {}'.format(self.cql, db_type)
 
     def get_update_statement(self, val, prev, ctx):
         """
@@ -813,7 +813,7 @@ class Map(BaseContainerColumn):
             self.key_type.db_type,
             self.value_type.db_type
         )
-        return '{} {}'.format(self.db_field_name, db_type)
+        return '{} {}'.format(self.cql, db_type)
 
     def validate(self, value):
         val = super(Map, self).validate(value)

--- a/cqlengine/tests/columns/test_container_columns.py
+++ b/cqlengine/tests/columns/test_container_columns.py
@@ -522,3 +522,23 @@ class TestMapColumn(BaseCassEngTestCase):
 #        assert len([v for v in ctx.values() if [7,8,9] == v.value]) == 1
 #        assert len([s for s in statements if '"TEST" = "TEST" +' in s]) == 1
 #        assert len([s for s in statements if '+ "TEST"' in s]) == 1
+
+class TestCamelMapModel(Model):
+    partition = columns.UUID(primary_key=True, default=uuid4)
+    camelMap = columns.Map(columns.Text, columns.Integer, required=False)
+
+class TestCamelMapColumn(BaseCassEngTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestCamelMapColumn, cls).setUpClass()
+        drop_table(TestCamelMapModel)
+        sync_table(TestCamelMapModel)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestCamelMapColumn, cls).tearDownClass()
+        drop_table(TestCamelMapModel)
+
+    def test_camelcase_column(self):
+        TestCamelMapModel.create(partition=None, camelMap={'blah': 1})
+


### PR DESCRIPTION
The current implementation omits the quotation marks around container column names when creating a new table, which cause the attached unit test to fail.

The desired functionality already implemented in the base Column class, I just copied it to BaseContainerColumn and Map classes.  
