### PR TITLE
Removed mixture of UTC and Timezone-specific handling of timestamps

### DIFF
--- a/cqlengine/query.py
+++ b/cqlengine/query.py
@@ -107,9 +107,9 @@ class BatchQuery(object):
             if isinstance(self.timestamp, (int, long)):
                 ts = self.timestamp
             elif isinstance(self.timestamp, timedelta):
-                ts = long((datetime.now() + self.timestamp - datetime.fromtimestamp(0)).total_seconds() * 1000000)
+                ts = long((datetime.utcnow() + self.timestamp - datetime.utcfromtimestamp(0)).total_seconds() * 1000000)
             elif isinstance(self.timestamp, datetime):
-                ts = long((self.timestamp - datetime.fromtimestamp(0)).total_seconds() * 1000000)
+                ts = long((self.timestamp - datetime.utcfromtimestamp(0)).total_seconds() * 1000000)
             else:
                 raise ValueError("Batch expects a long, a timedelta, or a datetime")
 

--- a/cqlengine/statements.py
+++ b/cqlengine/statements.py
@@ -492,11 +492,11 @@ class BaseCQLStatement(object):
             return self.timestamp
 
         if isinstance(self.timestamp, timedelta):
-            tmp = datetime.now() + self.timestamp
+            tmp = datetime.utcnow() + self.timestamp
         else:
             tmp = self.timestamp
 
-        return long(((tmp - datetime.fromtimestamp(0)).total_seconds()) * 1000000)
+        return long(((tmp - datetime.utcfromtimestamp(0)).total_seconds()) * 1000000)
 
     def __unicode__(self):
         raise NotImplementedError


### PR DESCRIPTION
Timestamp handling contained mixture of UTC (in code, and cassandra default) and timezone-specific.
I replaced the datetime's now and fromtimestamp calls with utcnow and utcfromtimestamp.

This also solves the bug on issue #167
