### PR TITLE
fixed issue with timestamp and DST

### DIFF
--- a/cqlengine/query.py
+++ b/cqlengine/query.py
@@ -1,4 +1,5 @@
 import copy
+import time
 from datetime import datetime, timedelta
 from cqlengine import BaseContainerColumn, Map, columns
 from cqlengine.columns import Counter, List, Set
@@ -150,10 +151,11 @@ class BatchQuery(object):
 
             if isinstance(self.timestamp, (int, long)):
                 ts = self.timestamp
-            elif isinstance(self.timestamp, timedelta):
-                ts = long((datetime.now() + self.timestamp - datetime.fromtimestamp(0)).total_seconds() * 1000000)
-            elif isinstance(self.timestamp, datetime):
-                ts = long((self.timestamp - datetime.fromtimestamp(0)).total_seconds() * 1000000)
+            elif isinstance(self.timestamp, (datetime, timedelta)):
+                ts = self.timestamp
+                if isinstance(self.timestamp, timedelta):
+                    ts += datetime.now()  # Apply timedelta
+                long(time.mktime(ts.timetuple()) * 1e+6 + ts.microsecond)
             else:
                 raise ValueError("Batch expects a long, a timedelta, or a datetime")
 

--- a/cqlengine/statements.py
+++ b/cqlengine/statements.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timedelta
 from cqlengine.functions import QueryValue
 from cqlengine.operators import BaseWhereOperator, InOperator
@@ -496,7 +497,7 @@ class BaseCQLStatement(object):
         else:
             tmp = self.timestamp
 
-        return long(((tmp - datetime.fromtimestamp(0)).total_seconds()) * 1000000)
+        return long(time.mktime(tmp.timetuple()) * 1e+6 + tmp.microsecond)
 
     def __unicode__(self):
         raise NotImplementedError


### PR DESCRIPTION
Current implementation used datetime.fromtimestamp to calculate microseconds from epoch,
however it is unaware of DST (without explicitly setting tzinfo- datetime's dst is always None).

I switched to time.mktime which is aware of the locale DST.

This should be the correct solution for #167
