### PR TITLE
count() doesn't apply limit()

### DIFF
--- a/cqlengine/tests/query/test_queryset.py
+++ b/cqlengine/tests/query/test_queryset.py
@@ -234,6 +234,13 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
         q = TestModel.objects(TestModel.test_id == 0)
         assert q.count() == 4
 
+    def test_query_limit_count(self):
+        """ Tests that adding query with a limit affects the count as expected """
+        assert TestModel.objects.count() == 12
+
+        q = TestModel.objects(TestModel.test_id == 0).limit(2)
+        assert q.count() == 2
+
     def test_iteration(self):
         """ Tests that iterating over a query set pulls back all of the expected results """
         q = TestModel.objects(test_id=0)


### PR DESCRIPTION
A query with an explicit limit doesn't apply the said limit on a count request.

In the attached unit test, the statement:

``` python
TestModel.objects(TestModel.test_id == 0).limit(2).count()
```

execute the following CQL query:

``` sql
SELECT COUNT(*) FROM cqlengine_test.test_model WHERE "test_id" = :0 {'0': 0L};
```

Here, I expect cqlengine to produce:

``` sql
SELECT COUNT(*) FROM cqlengine_test.test_model WHERE "test_id" = :0 {'0': 0L} LIMIT 2;
```
