### PR TITLE
Make default values available on instantiation

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,9 @@
 CHANGELOG
 
+0.13.0-dev
+
+* Make default column values available on instantiation.
+
 0.12.0
 
 * Normalize and unquote boolean values. (Thanks Kevin Deldycke github.com/kdeldycke)

--- a/cqlengine/models.py
+++ b/cqlengine/models.py
@@ -266,7 +266,8 @@ class BaseModel(object):
         self._timestamp = None
 
         for name, column in self._columns.items():
-            value =  values.get(name, None)
+            column_default = column.get_default() if column.has_default else None
+            value = values.get(name, column_default)
             if value is not None or isinstance(column, columns.BaseContainerColumn):
                 value = column.to_python(value)
             value_mngr = column.value_manager(self, column, value)
@@ -285,8 +286,6 @@ class BaseModel(object):
         return '{} <{}>'.format(self.__class__.__name__,
                                 ', '.join(('{}={}'.format(k, getattr(self, k)) for k,v in self._primary_keys.iteritems()))
                                 )
-
-
 
     @classmethod
     def _discover_polymorphic_submodels(cls):

--- a/cqlengine/tests/model/test_class_construction.py
+++ b/cqlengine/tests/model/test_class_construction.py
@@ -22,17 +22,38 @@ class TestModelClassFunction(BaseCassEngTestCase):
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             text = columns.Text()
 
-        #check class attibutes
+        # Check class attibutes
         self.assertHasAttr(TestModel, '_columns')
         self.assertHasAttr(TestModel, 'id')
         self.assertHasAttr(TestModel, 'text')
 
-        #check instance attributes
+        # Check instance attributes
         inst = TestModel()
         self.assertHasAttr(inst, 'id')
         self.assertHasAttr(inst, 'text')
-        self.assertIsNone(inst.id)
         self.assertIsNone(inst.text)
+        self.assertIsNotNone(inst.id)
+
+    def test_values_on_instantiation(self):
+        """
+        Tests defaults and user-provided values on instantiation.
+        """
+
+        class TestPerson(Model):
+            first_name = columns.Text(primary_key=True, default='kevin')
+            last_name = columns.Text(default='something')
+
+        # Check that defaults are available at instantiation.
+        inst1 = TestPerson()
+        self.assertHasAttr(inst1, 'first_name')
+        self.assertHasAttr(inst1, 'last_name')
+        self.assertEquals(inst1.first_name, 'kevin')
+        self.assertEquals(inst1.last_name, 'something')
+
+        # Check that values on instantiation overrides defaults.
+        inst2 = TestPerson(first_name='bob', last_name='joe')
+        self.assertEquals(inst2.first_name, 'bob')
+        self.assertEquals(inst2.last_name, 'joe')
 
     def test_db_map(self):
         """

--- a/cqlengine/tests/model/test_model_io.py
+++ b/cqlengine/tests/model/test_model_io.py
@@ -9,11 +9,6 @@ from cqlengine.management import delete_table
 from cqlengine.models import Model
 from cqlengine import columns
 
-class TestModel(Model):
-    id      = columns.UUID(primary_key=True, default=lambda:uuid4())
-    count   = columns.Integer()
-    text    = columns.Text(required=False)
-    a_bool  = columns.Boolean(default=False)
 
 class TestModel(Model):
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())

--- a/cqlengine/tests/model/test_model_io.py
+++ b/cqlengine/tests/model/test_model_io.py
@@ -36,9 +36,24 @@ class TestModelIO(BaseCassEngTestCase):
 
     def test_model_save_and_load(self):
         """
-        Tests that models can be saved and retrieved
+        Tests that models can be saved and retrieved, using the create() method.
         """
         tm = TestModel.create(count=8, text='123456789')
+        tm2 = TestModel.objects(id=tm.pk).first()
+
+        for cname in tm._columns.keys():
+            self.assertEquals(getattr(tm, cname), getattr(tm2, cname))
+
+    def test_model_instantiation_save_and_load(self):
+        """
+        Tests that models can be saved and retrieved, this time using the natural model instantiation.
+        """
+        tm = TestModel(count=8, text='123456789')
+        # Tests that values are available on instantiation.
+        self.assertIsNotNone(tm['id'])
+        self.assertEquals(tm.count, 8)
+        self.assertEquals(tm.text, '123456789')
+        tm.save()
         tm2 = TestModel.objects(id=tm.pk).first()
 
         for cname in tm._columns.keys():


### PR DESCRIPTION
On instantiation, default column values are not available. See:

``` python
>>> from cqlengine import columns
>>> from cqlengine.models import Model
>>> class Person(Model):
...     first_name = columns.Text(primary_key=True)
...     last_name = columns.Text(default='something')
... 
>>> p1 = Person(first_name='bob')
>>> p1.first_name
'bob'
>>> p1.last_name
>>> 
```

Here I expect `p1.last_name` to return `'something'`, but it's not the case. This PR fix this issue.
