### PR TITLE
Track column's changed state since instantiation

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,9 @@
 CHANGELOG
 
+0.13.0-dev
+
+* Make default column values available on instantiation.
+
 0.12.0
 
 * Normalize and unquote boolean values. (Thanks Kevin Deldycke github.com/kdeldycke)

--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ CHANGELOG
 0.13.0-dev
 
 * Make default column values available on instantiation.
+* Detect changed columns on instantiation.
 
 0.12.0
 

--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -17,32 +17,33 @@ class BaseValueManager(object):
         self.column = column
         self.previous_value = deepcopy(value)
         self.value = value
+        self.changed = False
 
     @property
     def deleted(self):
-        return self.value is None and self.previous_value is not None
+        return self.value is None and self.changed
 
-    @property
-    def changed(self):
+    def track_changed(self):
         """
-        Indicates whether or not this value has changed.
-
-        :rtype: boolean
-
+        Maintain the state of the ``changed`` boolean.
         """
-        return self.value != self.previous_value
+        if self.value != self.previous_value:
+            self.changed = True
 
     def reset_previous_value(self):
         self.previous_value = deepcopy(self.value)
+        self.changed = False
 
     def getval(self):
         return self.value
 
     def setval(self, val):
         self.value = val
+        self.track_changed()
 
     def delval(self):
         self.value = None
+        self.track_changed()
 
     def get_property(self):
         _get = lambda slf: self.getval()

--- a/cqlengine/models.py
+++ b/cqlengine/models.py
@@ -278,6 +278,14 @@ class BaseModel(object):
         self._is_persisted = False
         self._batch = None
 
+    def _reset_state(self):
+        """
+        Mark the instance as in sync with its in-database copy.
+        """
+        # Reset the value managers.
+        for v in self._values.values():
+            v.reset_previous_value()
+        self._is_persisted = True
 
     def __repr__(self):
         """
@@ -339,7 +347,7 @@ class BaseModel(object):
             klass = cls
 
         instance = klass(**field_dict)
-        instance._is_persisted = True
+        instance._reset_state()
         return instance
 
     def _can_update(self):
@@ -501,10 +509,7 @@ class BaseModel(object):
                           timestamp=self._timestamp,
                           consistency=self.__consistency__).save()
 
-        #reset the value managers
-        for v in self._values.values():
-            v.reset_previous_value()
-        self._is_persisted = True
+        self._reset_state()
 
         self._ttl = None
         self._timestamp = None
@@ -539,10 +544,7 @@ class BaseModel(object):
                           timestamp=self._timestamp,
                           consistency=self.__consistency__).update()
 
-        #reset the value managers
-        for v in self._values.values():
-            v.reset_previous_value()
-        self._is_persisted = True
+        self._reset_state()
 
         self._ttl = None
         self._timestamp = None

--- a/cqlengine/models.py
+++ b/cqlengine/models.py
@@ -266,7 +266,8 @@ class BaseModel(object):
         self._timestamp = None
 
         for name, column in self._columns.items():
-            value =  values.get(name, None)
+            column_default = column.get_default() if column.has_default else None
+            value = values.get(name, column_default)
             if value is not None or isinstance(column, columns.BaseContainerColumn):
                 value = column.to_python(value)
             value_mngr = column.value_manager(self, column, value)
@@ -285,8 +286,6 @@ class BaseModel(object):
         return '{} <{}>'.format(self.__class__.__name__,
                                 ', '.join(('{}={}'.format(k, getattr(self, k)) for k,v in self._primary_keys.iteritems()))
                                 )
-
-
 
     @classmethod
     def _discover_polymorphic_submodels(cls):

--- a/cqlengine/tests/model/test_class_construction.py
+++ b/cqlengine/tests/model/test_class_construction.py
@@ -22,17 +22,38 @@ class TestModelClassFunction(BaseCassEngTestCase):
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             text = columns.Text()
 
-        #check class attibutes
+        # Check class attibutes
         self.assertHasAttr(TestModel, '_columns')
         self.assertHasAttr(TestModel, 'id')
         self.assertHasAttr(TestModel, 'text')
 
-        #check instance attributes
+        # Check instance attributes
         inst = TestModel()
         self.assertHasAttr(inst, 'id')
         self.assertHasAttr(inst, 'text')
-        self.assertIsNone(inst.id)
         self.assertIsNone(inst.text)
+        self.assertIsNotNone(inst.id)
+
+    def test_values_on_instantiation(self):
+        """
+        Tests defaults and user-provided values on instantiation.
+        """
+
+        class TestPerson(Model):
+            first_name = columns.Text(primary_key=True, default='kevin')
+            last_name = columns.Text(default='something')
+
+        # Check that defaults are available at instantiation.
+        inst1 = TestPerson()
+        self.assertHasAttr(inst1, 'first_name')
+        self.assertHasAttr(inst1, 'last_name')
+        self.assertEquals(inst1.first_name, 'kevin')
+        self.assertEquals(inst1.last_name, 'something')
+
+        # Check that values on instantiation overrides defaults.
+        inst2 = TestPerson(first_name='bob', last_name='joe')
+        self.assertEquals(inst2.first_name, 'bob')
+        self.assertEquals(inst2.last_name, 'joe')
 
     def test_db_map(self):
         """

--- a/cqlengine/tests/model/test_class_construction.py
+++ b/cqlengine/tests/model/test_class_construction.py
@@ -37,6 +37,9 @@ class TestModelClassFunction(BaseCassEngTestCase):
     def test_values_on_instantiation(self):
         """
         Tests defaults and user-provided values on instantiation.
+
+        Also checks that columns are marked as changed.
+        See #174.
         """
 
         class TestPerson(Model):
@@ -49,11 +52,15 @@ class TestModelClassFunction(BaseCassEngTestCase):
         self.assertHasAttr(inst1, 'last_name')
         self.assertEquals(inst1.first_name, 'kevin')
         self.assertEquals(inst1.last_name, 'something')
+        self.assertEquals(sorted(inst1.get_changed_columns()),
+                          sorted(['first_name', 'last_name']))
 
         # Check that values on instantiation overrides defaults.
         inst2 = TestPerson(first_name='bob', last_name='joe')
         self.assertEquals(inst2.first_name, 'bob')
         self.assertEquals(inst2.last_name, 'joe')
+        self.assertEquals(sorted(inst1.get_changed_columns()),
+                          sorted(['first_name', 'last_name']))
 
     def test_db_map(self):
         """

--- a/cqlengine/tests/model/test_model_io.py
+++ b/cqlengine/tests/model/test_model_io.py
@@ -9,11 +9,6 @@ from cqlengine.management import delete_table
 from cqlengine.models import Model
 from cqlengine import columns
 
-class TestModel(Model):
-    id      = columns.UUID(primary_key=True, default=lambda:uuid4())
-    count   = columns.Integer()
-    text    = columns.Text(required=False)
-    a_bool  = columns.Boolean(default=False)
 
 class TestModel(Model):
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())

--- a/cqlengine/tests/model/test_model_io.py
+++ b/cqlengine/tests/model/test_model_io.py
@@ -200,6 +200,14 @@ class TestUpdating(BaseCassEngTestCase):
         self.instance.save()
         assert self.instance.get_changed_columns() == []
 
+    def test_get_changed_columns_on_instantiation(self):
+        instance = TestMultiKeyModel(
+            partition=random.randint(0, 1000),
+            cluster=random.randint(0, 1000),
+        )
+        self.assertEquals(sorted(instance.get_changed_columns()),
+                          sorted(['partition', 'cluster']))
+
 
 class TestCanUpdate(BaseCassEngTestCase):
 

--- a/cqlengine/tests/model/test_model_io.py
+++ b/cqlengine/tests/model/test_model_io.py
@@ -36,9 +36,24 @@ class TestModelIO(BaseCassEngTestCase):
 
     def test_model_save_and_load(self):
         """
-        Tests that models can be saved and retrieved
+        Tests that models can be saved and retrieved, using the create() method.
         """
         tm = TestModel.create(count=8, text='123456789')
+        tm2 = TestModel.objects(id=tm.pk).first()
+
+        for cname in tm._columns.keys():
+            self.assertEquals(getattr(tm, cname), getattr(tm2, cname))
+
+    def test_model_instantiation_save_and_load(self):
+        """
+        Tests that models can be saved and retrieved, this time using the natural model instantiation.
+        """
+        tm = TestModel(count=8, text='123456789')
+        # Tests that values are available on instantiation.
+        self.assertIsNotNone(tm['id'])
+        self.assertEquals(tm.count, 8)
+        self.assertEquals(tm.text, '123456789')
+        tm.save()
         tm2 = TestModel.objects(id=tm.pk).first()
 
         for cname in tm._columns.keys():


### PR DESCRIPTION
Is there a reason a column, set during instanciation, is not marked as changed, while it is when sets by an attribute ?

For example, in the following code, I expect the first call to `p1.get_changed_columns()` to returns `['last_name']`, as `p2` does:

``` python
>>> from cqlengine import columns
>>> from cqlengine.models import Model
>>> class Person(Model):
...     first_name = columns.Text(primary_key=True)
...     last_name = columns.Text(default='something')
... 
>>> p1 = Person(first_name='bob', last_name='joe')
>>> p1.get_changed_columns()
[]
>>> p2 = Person(first_name='john')
>>> p2.get_changed_columns()
[]
>>> p2.last_name = 'james'
>>> p2.get_changed_columns()
['last_name']
>>> 
```

Is this a design choice or an issue ?
