### PR TITLE
add event feature

### DIFF
--- a/cqlengine/events.py
+++ b/cqlengine/events.py
@@ -1,0 +1,179 @@
+"""
+Allow the sources code to subscribe event. The currently available events are:
+1. BeforeSave
+2. AfterSaved
+3. BeforeUpdate
+4. AfterUpdated
+3. BeforeDelete
+4. AfterDeleted
+"""
+
+import collections
+
+
+class EventSubscribers(collections.MutableSet):
+    """
+    Manage all subscribers for an event class
+    Notify an event to all its subscribers
+
+    This class also simulates the OrderedSet as recommendation from
+      https://docs.python.org/2/library/collections.html
+      http://code.activestate.com/recipes/576694/
+    """
+
+    def __init__(self, event_class):
+        self._event_class = event_class
+        self.end = []
+        self.end += [None, self.end, self.end]   # sentinel node for doubly linked list
+        self.map = {}                           # key --> [key, prev, next]
+
+    def add(self, key):
+        if key not in self.map:
+            end = self.end
+            curr = end[1]
+            curr[2] = end[1] = self.map[key] = [key, curr, end]
+
+    def discard(self, key):
+        if key in self.map:
+            key, prev, next = self.map.pop(key)
+            prev[2] = next
+            next[1] = prev
+
+    def __iter__(self):
+        end = self.end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def pop(self, last=True):
+        if not self:
+            raise KeyError('set is empty')
+        key = self.end[1][0] if last else self.end[2][0]
+        self.discard(key)
+        return key
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, list(self))
+
+    def __eq__(self, other):
+        if isinstance(other, EventSubscribers):
+            return len(self) == len(other) and list(self) == list(other)
+        return set(self) == set(other)
+
+    def __len__(self):
+        return len(self.map)
+
+    def __contains__(self, key):
+        return key in self.map
+
+    def notify(self, event):
+        assert type(event) == self._event_class
+        for fn in self:
+            fn(event)
+
+
+class ModelEventMetaClass(type):
+    def __new__(mcs, name, bases, attrs):
+        """
+        Create the class and add a dispatcher to it
+        """
+        klass = super(ModelEventMetaClass, mcs).__new__(mcs, name, bases, attrs)
+        klass._subscribers = EventSubscribers(klass)
+        return klass
+
+
+class ModelEvent(object):
+    """
+    Base class for all model's events
+    """
+    __metaclass__ = ModelEventMetaClass
+
+    def __init__(self, dmlquery):
+        """
+        create new event instance from a dmlquery
+        :param cqlengine.query.DMLQuery dmlquery: the DMLQuery that new event is created on
+        """
+        self.dmlquery = dmlquery
+
+    @property
+    def model(self):
+        return self.dmlquery.model
+
+    @property
+    def instance(self):
+        return self.dmlquery.instance
+
+    @property
+    def batch(self):
+        return self.dmlquery._batch
+
+    @property
+    def ttl(self):
+        return self.dmlquery._ttl
+
+    @property
+    def consistency(self):
+        return self.dmlquery._consistency
+
+    @property
+    def timestamp(self):
+        return self.dmlquery._timestamp
+
+    @classmethod
+    def notify(cls, dmlquery):
+        """
+        Create new event from dmlquery and notify it
+        :param cqlengine.query.DMLQuery dmlquery: the DMLQuery that new event is created on
+        """
+        cls._subscribers.notify(cls(dmlquery))
+
+
+def add_subscriber(subscriber, *events):
+    """
+    Add a subscriber to an event
+    :param callable subscriber: subscriber to be added
+    :param list[type] events: the classes of events that subscriber want to subscribe on
+    """
+    for event in events:
+        event._subscribers.add(subscriber)
+
+
+def subscriber(*events):
+    """
+    Decorator will add the function
+    being decorated as an event subscriber for the set events passed
+    to the decorator arguments.
+
+    More than one event type can be passed into arguments. The
+    decorated subscriber will be called for each event type.
+
+    For example:
+
+    .. code-block:: python
+
+       from cqlengine.events import subscriber
+       from app.db import CFModel
+
+       @subscriber(CFModel.AfterSave, CFModel.AfterUpdate)
+       def mysubscriber(event):
+           print 'Model "%s" has just changed through instance "%s"' \
+                % (event.model, event.instance)
+
+    :param list<ModelEvent> events: the events to be add subscriber on
+    """
+    def _register_subscriber(fn):
+        add_subscriber(fn, *events)
+        return fn
+
+    assert len(events), 'You have to specify at least an event'
+    return _register_subscriber

--- a/cqlengine/tests/test_events.py
+++ b/cqlengine/tests/test_events.py
@@ -1,0 +1,155 @@
+"""
+Test the event feature, including register subscribers and event firing
+"""
+
+from uuid import uuid4
+from cqlengine.query import BatchQuery
+from cqlengine.management import drop_table, sync_table
+from cqlengine.tests.base import BaseCassEngTestCase
+from cqlengine.models import Model, columns
+from cqlengine.events import add_subscriber, subscriber
+
+
+class TestEventModel(Model):
+    id = columns.UUID(primary_key=True, default=uuid4)
+    name = columns.Text()
+
+
+class TestEvent(BaseCassEngTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestEvent, cls).setUpClass()
+        # drop_table(TestEventModel)
+        sync_table(TestEventModel)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestEvent, cls).tearDownClass()
+        drop_table(TestEventModel)
+
+    def test_add_subscriber(self):
+        @subscriber(TestEventModel.BeforeSave, TestEventModel.AfterSaved)
+        def subscriber_A(e): pass
+        def subscriber_B(e): pass
+
+        add_subscriber(subscriber_B, TestEventModel.BeforeSave, TestEventModel.BeforeDelete)
+
+        self.assertEqual(len(TestEventModel.BeforeSave._subscribers), 2)
+        self.assertEqual(len(TestEventModel.AfterSaved._subscribers), 1)
+        self.assertEqual(len(TestEventModel.BeforeDelete._subscribers), 1)
+        self.assertIn(subscriber_A, TestEventModel.BeforeSave._subscribers)
+        self.assertIn(subscriber_A, TestEventModel.AfterSaved._subscribers)
+        self.assertIn(subscriber_B, TestEventModel.BeforeSave._subscribers)
+        self.assertIn(subscriber_B, TestEventModel.BeforeDelete._subscribers)
+
+
+    def test_receive_event(self):
+        received_events = []
+        def assert_event(instance, event):
+            for e in received_events:
+                if isinstance(e, event) and e.instance is instance:
+                    return
+            self.assertTrue(False, 'The expected event "%s" for "%s" did not come'
+                                   % (event, instance))
+
+        @subscriber(TestEventModel.BeforeSave,
+                    TestEventModel.BeforeUpdate,
+                    TestEventModel.BeforeDelete)
+        def subscriber_before(e):
+            received_events.append(e)
+
+        @subscriber(TestEventModel.AfterSaved,
+                    TestEventModel.AfterUpdated,
+                    TestEventModel.AfterDeleted)
+        def subsriber_after(e):
+            if e.__class__ is TestEventModel.AfterSaved:
+                before_cls = TestEventModel.BeforeSave
+            elif e.__class__ is TestEventModel.AfterUpdated:
+                before_cls = TestEventModel.BeforeUpdate
+            elif e.__class__ is TestEventModel.AfterDeleted:
+                before_cls = TestEventModel.BeforeDelete
+            else:
+                assert False, 'Unknow "%s" event class' % e.__class__
+            assert_event(e.instance, before_cls) # verify that the before event has came
+            received_events.append(e)
+
+        t1 = TestEventModel(name='Terk')
+        t1.save()
+
+        assert_event(t1, TestEventModel.BeforeSave)
+        assert_event(t1, TestEventModel.AfterSaved)
+
+        t2 = TestEventModel(name='Tarzan')
+        t2.update(name='Tantor')
+
+        assert_event(t2, TestEventModel.BeforeUpdate)
+        assert_event(t2, TestEventModel.AfterUpdated)
+
+        t3 = TestEventModel.objects.filter(TestEventModel.id == t2.id).get()
+        t3.delete()
+
+        assert_event(t3, TestEventModel.BeforeDelete)
+        assert_event(t3, TestEventModel.AfterDeleted)
+
+        t4 = TestEventModel.create(name='Jane')
+
+        assert_event(t4, TestEventModel.BeforeSave)
+        assert_event(t4, TestEventModel.AfterSaved)
+
+    def test_receive_events_in_batch(self):
+        received_events = []
+        batch = BatchQuery()
+
+        def assert_event(instance, event):
+            for e in received_events:
+                if isinstance(e, event) \
+                        and e.instance is instance\
+                        and e.batch is batch:
+                    return
+            self.assertTrue(False, 'The expected event "%s" for "%s" did not come'
+                                   % (event, instance))
+
+        @subscriber(TestEventModel.BeforeSave,
+                    TestEventModel.BeforeUpdate,
+                    TestEventModel.BeforeDelete)
+        def subscriber_before(e):
+            received_events.append(e)
+
+        @subscriber(TestEventModel.AfterSaved,
+                    TestEventModel.AfterUpdated,
+                    TestEventModel.AfterDeleted)
+        def subsriber_after(e):
+            if e.__class__ is TestEventModel.AfterSaved:
+                before_cls = TestEventModel.BeforeSave
+            elif e.__class__ is TestEventModel.AfterUpdated:
+                before_cls = TestEventModel.BeforeUpdate
+            elif e.__class__ is TestEventModel.AfterDeleted:
+                before_cls = TestEventModel.BeforeDelete
+            else:
+                assert False, 'Unknow "%s" event class' % e.__class__
+            assert_event(e.instance, before_cls) # verify that the before event has came
+            received_events.append(e)
+
+        t1 = TestEventModel(name='Terk')
+        t1.batch(batch).save()
+
+        assert_event(t1, TestEventModel.BeforeSave)
+        assert_event(t1, TestEventModel.AfterSaved)
+
+        t2 = TestEventModel(name='Tarzan')
+        t2.batch(batch).update(name='Tantor')
+
+        assert_event(t2, TestEventModel.BeforeUpdate)
+        assert_event(t2, TestEventModel.AfterUpdated)
+
+        t3 = TestEventModel(id=t2.id)
+        t3.batch(batch).delete()
+
+        assert_event(t3, TestEventModel.BeforeDelete)
+        assert_event(t3, TestEventModel.AfterDeleted)
+
+        t4 = TestEventModel.batch(batch).create(name='Jane')
+
+        assert_event(t4, TestEventModel.BeforeSave)
+        assert_event(t4, TestEventModel.AfterSaved)

--- a/docs/topics/event.rst
+++ b/docs/topics/event.rst
@@ -1,0 +1,121 @@
+=====
+Event
+=====
+
+.. module:: cqlengine.events
+
+This feature allows cqlengine to notify events when a model's instance got
+*save/update/delete*.
+
+    **Note**: It does not work with update/delete by ModelQuery likes without
+    model object instance.
+
+
+Available events
+================
+
++------------------------+----------------------------------------------------------+
+| Name                   | Notified on                                              |
++========================+==========================================================+
+| ``Model.BeforeSave``   | Before the ``.save()`` or ``.create()`` function is      |
+|                        | called.                                                  |
++------------------------+----------------------------------------------------------+
+| ``Model.AfterSaved``   | After the ``.save()`` or ``.create()`` function is       |
+|                        | called successfully.                                     |
++------------------------+----------------------------------------------------------+
+| ``Model.BeforeUpdate`` | Before the ``update()`` function is called.              |
++------------------------+----------------------------------------------------------+
+| ``Model.AfterUpdated`` | After the ``update()`` function is called successfully.  |
++------------------------+----------------------------------------------------------+
+| ``Model.BeforeDelete`` | Before the ``delete()`` function is called.              |
++------------------------+----------------------------------------------------------+
+| ``Model.AfterDeleted`` | After the ``delete()`` function is called successfully.  |
++------------------------+----------------------------------------------------------+
+
+Add subscriber to events
+========================
+
+You can add a subscriber to 1+ events by call ``cqlengine.events.add_subscriber``
+or use decorator ``cqlengine.events.subscriber`` for the subscriber function.
+
+Examples
+--------
+
+.. code-block:: python
+
+    from cqlengine.models import Model, columns
+    from cqlengine.events import subscriber, add_subscriber
+
+    class Person(Model):
+        first_name  = columns.Text()
+        last_name = columns.Text()
+
+    @subscriber(Person.AfterSaved) # add subscriber by decorator
+    def on_person_saved(e):
+        print e
+
+    def before_person_save(e):
+        print e
+
+    @subscriber(Person.AfterSaved, Person.AfterUpdated)
+    def after_person_changed(e):
+        pass
+
+    add_subscriber(before_person_save, Person.BeforeSave) # add subscriber by function
+
+    p = Person(first_name='John')
+    p.save() # ``before_person_save``, ``on_person_saved``, ``after_person_changed`` will be called in order.
+
+    p.update(last_name='Eggleston') # ``after_person_changed`` will be called
+
+
+APIs
+====
+
+.. function:: add_subscriber(subscriber, \*events)
+
+    Add a subscriber to an event
+    :param callable subscriber: subscriber to be added
+    :param list[type] events: the classes of events that subscriber want to subscribe on
+
+.. decorator:: subscriber(\*events)
+
+    Decorator will add the function
+    being decorated as an event subscriber for the set events passed
+    to the decorator arguments.
+
+    More than one event type can be passed into arguments. The
+    decorated subscriber will be called for each event type.
+
+    For example:
+
+    .. code-block:: python
+
+       from cqlengine.events import subscriber
+       from app.db import CFModel
+
+       @subscriber(CFModel.AfterSave, CFModel.AfterUpdate)
+       def mysubscriber(event):
+           print 'Model "%s" has just changed through instance "%s"' \
+                % (event.model, event.instance)
+
+    :param list<ModelEvent> events: the events to be add subscriber on
+
+
+.. class:: ModelEvent(dmlquery)
+
+    create new event instance from a dmlquery
+    :param cqlengine.query.DMLQuery dmlquery: the DMLQuery that new event is created on
+
+    .. attribute:: model
+
+        The class of the object that event is created on its change.
+
+    .. attribute:: instance
+
+        The install of the object that event is created on its change.
+
+    .. attribute:: batch
+
+        The BatchQuery instance that current object is being changed on, ``None``
+        if there is no batch.


### PR DESCRIPTION
Guys, I have posted an issue about model update hooking (#182). I did make an event feature that allows developers to listen/subscribe on Model's event (update/save/delete). Please take a look on it.

This is the first time I make code for an opensource, I've make some modification before but they are just for me only. Please comment on my mistake and give me some advice.
### Event feature
1. Each model class has its own 6 events: Before|After Save|Update|Delete.
2. Those events can be subscribed by `add_subscriber``function or`subscriber` decorator.
3. Those events will be fired from `DMLQuery.save()`, `DMLQuery.update()`, `DMLQuery.delete()` function.

What do you say?
