### PR TITLE
Changed connection error messages to be more informative

### DIFF
--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -94,9 +94,9 @@ def setup(
             try:
                 port = int(host[1])
             except ValueError:
-                raise CQLConnectionError("Can't parse {}".format(''.join(host)))
+                raise CQLConnectionError("Can't parse port as int {}".format(':'.join(host)))
         else:
-            raise CQLConnectionError("Can't parse {}".format(''.join(host)))
+            raise CQLConnectionError("Can't parse host string {}".format(':'.join(host)))
 
         _hosts.append(Host(host[0], port))
 


### PR DESCRIPTION
The connection error messages seem to be a little confusing, because they drop the colon from the host strings, and produce the same message for two different errors (see issue #194).
