### PR TITLE
Use Stable Version of Sure Package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ ipython==0.13.1
 ipdb==0.7
 Sphinx==1.1.3
 mock==1.0.1
-sure
+sure==1.2.5


### PR DESCRIPTION
The pip plumbing for the sure library seems to be horribly broken in 1.2.7, so I propose pegging to the stable version and getting the Travis tests working again.

See https://github.com/gabrielfalcao/sure/pull/60
