### PR TITLE
Unchanged primary key trigger error on update

### DIFF
--- a/cqlengine/tests/model/test_updates.py
+++ b/cqlengine/tests/model/test_updates.py
@@ -89,3 +89,7 @@ class ModelUpdateTests(BaseCassEngTestCase):
         with self.assertRaises(ValidationError):
             m0.update(partition=uuid4())
 
+    def test_noop_primary_key_update(self):
+        """ tests that assigning the same value on a primary key will do nothing. """
+        m0 = TestUpdateModel.create(count=5, text='monkey')
+        m0.update(partition=m0.partition)

--- a/cqlengine/tests/model/test_updates.py
+++ b/cqlengine/tests/model/test_updates.py
@@ -77,6 +77,15 @@ class ModelUpdateTests(BaseCassEngTestCase):
             m0.update(count=5)
         assert execute.call_count == 0
 
+    def test_noop_model_assignation_update(self):
+        """ tests that assigning the same value on a model will do nothing. """
+        m0 = TestUpdateModel.create(count=5, text='monkey')
+        m1 = TestUpdateModel.get(partition=m0.partition, cluster=m0.cluster)
+        m1.count = 5
+        with patch.object(ConnectionPool, 'execute') as execute:
+            m1.save()
+        assert execute.call_count == 0
+
     def test_invalid_update_kwarg(self):
         """ tests that passing in a kwarg to the update method that isn't a column will fail """
         m0 = TestUpdateModel.create(count=5, text='monkey')


### PR DESCRIPTION
When updating an instance, the unchanged primary key's value is not detected and raise an error:

``` python
======================================================================
ERROR: tests that assigning the same value on a primary key will do nothing.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kdeldycke/virtualenvs/cqlengine/cqlengine/cqlengine/tests/model/test_updates.py", line 104, in test_noop_primary_key_update
    m0.update(partition=m0.partition)
  File "/Users/kdeldycke/virtualenvs/cqlengine/cqlengine/cqlengine/models.py", line 530, in update
    raise ValidationError("Cannot apply update to primary key '{}' for {}.{}".format(k, self.__module__, self.__class__.__name__))
ValidationError: Cannot apply update to primary key 'partition' for cqlengine.tests.model.test_updates.TestUpdateModel
-------------------- >> begin captured logging << --------------------
cqlengine.cql: DEBUG: INSERT INTO cqlengine_test.test_update_model ("partition", "cluster", "count", "text") VALUES (:0, :1, :2, :3) {'1': UUID('5c8a74b9-ccda-421f-815b-0d4c41b7702b'), '0': UUID('6a164283-1679-4f99-a1c5-ee0e7a0cec0e'), '3': 'monkey', '2': 5L}
--------------------- >> end captured logging << ---------------------
```

I think CQLengine should properly detect unchanged column value here and allow update, as explained in the documentation:

```
If no fields on the model have been modified since loading, no query will be performed.
```

Source: https://cqlengine.readthedocs.org/en/latest/topics/models.html#cqlengine.models.Model.update
