### PR TITLE
connection speedup flags in setup.

### DIFF
--- a/cqlengine/connection.py
+++ b/cqlengine/connection.py
@@ -4,6 +4,7 @@
 
 from collections import namedtuple
 from cassandra.cluster import Cluster
+from cassandra.policies import HostDistance
 from cassandra.query import SimpleStatement, Statement
 
 try:
@@ -35,6 +36,8 @@ def setup(
         default_keyspace,
         consistency=ConsistencyLevel.ONE,
         lazy_connect=False,
+        skip_schema_loading=False,
+        one_core_connection=False,
         **kwargs):
     """
     Records the hosts and connects to one of them
@@ -47,6 +50,10 @@ def setup(
     :type consistency: int
     :param lazy_connect: True if should not connect until first use
     :type lazy_connect: bool
+    :param skip_schema_loading: True if should not load schema after connect. Will make connects faster. Will break prepared statements, and if you make a schema change, you won't properly wait for schema agreement.
+    :type skip_schema_loading: bool
+    :param one_core_connection: True if only one connection per host instead of 2
+    :type one_core_connection: bool
     """
     global cluster, session, default_consistency_level, lazy_connect_args
 
@@ -65,6 +72,10 @@ def setup(
         return
 
     cluster = Cluster(hosts, **kwargs)
+    if skip_schema_loading:
+        cluster.control_connection._refresh_schema = lambda *args, **kwargs: None
+    if one_core_connection:
+        cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
     session = cluster.connect()
     session.row_factory = dict_factory
 


### PR DESCRIPTION
In response to some very large connection times (10-70seconds) it has been recommended to try these speedups. Two of them required configuring the Cluster prior to connecting but could not be done with keyword arguments to Cluster (which setup passes in.) Two new keyword arguments are added to setup to allow speedups 1 and 5 below.
skip_schema_loaded and one_core_connection.

The rest of the speedups can be achieved by passing keyword arguments to setup. These are passed on to Cluster when it is created.

Speedup recommendations are:

1: cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
Opens one conn per host instead of 2

2: use WhiteListRoundRobinPolicy to restrict the nodes to a subset

3: cluster = Cluster(..., executor_threads=N)
Where N > 2. Increases concurrency of opening connections.

4: cluster = Cluster(..., compression=False)
Saves one round trip when opening connections

5: cluster.control_connection._refresh_schema = lambda _args, *_kwargs: None
Skips schema loading. This will break prepared statements, and if you make a schema change, you won't properly wait for schema agreement.
