### PR TITLE
Ignore iPython left-overs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ html/
 /data
 
 docs/_build
+
+#iPython
+*.ipynb


### PR DESCRIPTION
A `Untitled0.ipynb` file was left in the [cqlengine-0.18.1.tar.gz](https://pypi.python.org/packages/source/c/cqlengine/cqlengine-0.18.1.tar.gz#md5=a9cb831315c8a5f2e370a7d32fc77cb5) archive on PyPi.
