### PR TITLE
bump cassandra version to 1.2 in puppet manifest

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -33,14 +33,14 @@ class cassandra {
   
   exec {"download-cassandra":
     cwd => "/tmp",
-    command => "wget http://download.nextag.com/apache/cassandra/1.1.6/apache-cassandra-1.1.6-bin.tar.gz",
-    creates => "/tmp/apache-cassandra-1.1.6-bin.tar.gz",
+    command => "wget http://download.nextag.com/apache/cassandra/1.2.19/apache-cassandra-1.2.19-bin.tar.gz",
+    creates => "/tmp/apache-cassandra-1.2.19-bin.tar.gz",
     require => [Package["wget"], File["/etc/init/cassandra.conf"]]
   }
 
   exec {"install-cassandra":
     cwd => "/tmp",
-    command => "tar -xzf apache-cassandra-1.1.6-bin.tar.gz; mv apache-cassandra-1.1.6 /usr/local/cassandra",
+    command => "tar -xzf apache-cassandra-1.2.19-bin.tar.gz; mv apache-cassandra-1.2.19 /usr/local/cassandra",
     require => Exec["download-cassandra"],
     creates => "/usr/local/cassandra/bin/cassandra"
   }


### PR DESCRIPTION
Fixes #306. (Previous URL was returning a 404.)
