### PR TITLE
fix codeblock formatting

### DIFF
--- a/docs/topics/development.rst
+++ b/docs/topics/development.rst
@@ -30,15 +30,15 @@ Testing Locally
 
 Before testing, you'll need to set an environment variable to the version of Cassandra that's being tested.  The version cooresponds to the <Major><Minor> release, so for example if you're testing against Cassandra 2.1, you'd set the following:
 
-    .. code-block::bash
+.. code-block:: bash
 
-        export CASSANDRA_VERSION=20
+    export CASSANDRA_VERSION=20
 
 At the command line, execute:
 
-    .. code-block::bash
+.. code-block:: bash
 
-        bin/test.py
+    bin/test.py
 
 This is a wrapper for nose that also sets up the database connection.
 


### PR DESCRIPTION
Currently the code blocks on the development page aren't rendering properly:

![broken code blocks](https://cloud.githubusercontent.com/assets/3143117/5562414/e32bfc84-8de7-11e4-9cc1-ae5c7585014a.png)

This PR fixes the codeblock formatting in the development.rst file.
