### PR TITLE
Connect to Cassandra in setup_package for running tests with nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
   - "pip install -r requirements.txt --use-mirrors"
 
 script:
-  - "bin/test.py --no-skip"
+  - "nosetests cqlengine/tests --no-skip"

--- a/bin/test.py
+++ b/bin/test.py
@@ -1,30 +1,6 @@
 #!/usr/bin/env python
 
-import os
 import nose
-import sys
 
-sys.path.append("")
-
-# setup cassandra
-from cqlengine import connection
-
-try:
-    CASSANDRA_VERSION = int(os.environ["CASSANDRA_VERSION"])
-except:
-    print("CASSANDRA_VERSION must be set as an environment variable. One of (12, 20, 21)")
-    raise
-
-if os.environ.get('CASSANDRA_TEST_HOST'):
-    CASSANDRA_TEST_HOST = os.environ['CASSANDRA_TEST_HOST']
-else:
-    CASSANDRA_TEST_HOST = 'localhost'
-
-if CASSANDRA_VERSION < 20:
-    protocol_version = 1
-else:
-    protocol_version = 2
-
-connection.setup([CASSANDRA_TEST_HOST], protocol_version=protocol_version, default_keyspace='cqlengine_test')
 
 nose.main()

--- a/cqlengine/tests/__init__.py
+++ b/cqlengine/tests/__init__.py
@@ -1,0 +1,25 @@
+import os
+
+from cqlengine import connection
+
+def setup_package():
+    try:
+        CASSANDRA_VERSION = int(os.environ["CASSANDRA_VERSION"])
+    except:
+        print("CASSANDRA_VERSION must be set as an environment variable. "
+              "One of (12, 20, 21)")
+        raise
+
+    if os.environ.get('CASSANDRA_TEST_HOST'):
+        CASSANDRA_TEST_HOST = os.environ['CASSANDRA_TEST_HOST']
+    else:
+        CASSANDRA_TEST_HOST = 'localhost'
+
+    if CASSANDRA_VERSION < 20:
+        protocol_version = 1
+    else:
+        protocol_version = 2
+
+    connection.setup([CASSANDRA_TEST_HOST],
+                      protocol_version=protocol_version,
+                      default_keyspace='cqlengine_test')

--- a/cqlengine/tests/base.py
+++ b/cqlengine/tests/base.py
@@ -4,7 +4,10 @@ import sys
 import six
 from cqlengine.connection import get_session
 
+
 CASSANDRA_VERSION = int(os.environ['CASSANDRA_VERSION'])
+PROTOCOL_VERSION = 1 if CASSANDRA_VERSION < 20 else 2
+
 
 class BaseCassEngTestCase(TestCase):
 

--- a/cqlengine/tests/columns/test_static_column.py
+++ b/cqlengine/tests/columns/test_static_column.py
@@ -4,10 +4,9 @@ from cqlengine import Model
 from cqlengine import columns
 from cqlengine.management import sync_table, drop_table
 from cqlengine.models import ModelDefinitionException
-from cqlengine.tests.base import BaseCassEngTestCase, CASSANDRA_VERSION
-from cqlengine.connection import get_cluster
+from cqlengine.tests.base import BaseCassEngTestCase
+from cqlengine.tests.base import CASSANDRA_VERSION, PROTOCOL_VERSION
 
-cluster = get_cluster()
 
 class TestStaticModel(Model):
     __keyspace__ = 'test'
@@ -31,7 +30,7 @@ class TestStaticColumn(BaseCassEngTestCase):
         super(TestStaticColumn, cls).tearDownClass()
         drop_table(TestStaticModel)
 
-    @skipUnless(cluster.protocol_version >= 2, "only runs against the cql3 protocol v2.0")
+    @skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
     def test_mixed_updates(self):
         """ Tests that updates on both static and non-static columns work as intended """
         instance = TestStaticModel.create()
@@ -47,7 +46,7 @@ class TestStaticColumn(BaseCassEngTestCase):
         
         assert actual.static == "it's still shared"
 
-    @skipUnless(cluster.protocol_version >= 2, "only runs against the cql3 protocol v2.0")
+    @skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
     def test_static_only_updates(self):
         """ Tests that updates on static only column work as intended """
         instance = TestStaticModel.create()

--- a/cqlengine/tests/management/test_management.py
+++ b/cqlengine/tests/management/test_management.py
@@ -3,14 +3,14 @@ from cqlengine import ALL, CACHING_ALL, CACHING_NONE
 from cqlengine.connection import get_session
 from cqlengine.exceptions import CQLEngineException
 from cqlengine.management import  get_fields, sync_table, drop_table
-from cqlengine.tests.base import BaseCassEngTestCase, CASSANDRA_VERSION
+from cqlengine.tests.base import BaseCassEngTestCase
+from cqlengine.tests.base import CASSANDRA_VERSION, PROTOCOL_VERSION
 from cqlengine import management
 from cqlengine.tests.query.test_queryset import TestModel
 from cqlengine.models import Model
 from cqlengine import columns, SizeTieredCompactionStrategy, LeveledCompactionStrategy
 from unittest import skipUnless
-from cqlengine.connection import get_cluster
-cluster = get_cluster()
+
 
 class CreateKeyspaceTest(BaseCassEngTestCase):
     def test_create_succeeeds(self):
@@ -256,7 +256,7 @@ class NonModelFailureTest(BaseCassEngTestCase):
             sync_table(self.FakeModel)
 
 
-@skipUnless(cluster.protocol_version >= 2, "only runs against the cql3 protocol v2.0")
+@skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
 def test_static_columns():
     class StaticModel(Model):
         id = columns.Integer(primary_key=True)

--- a/cqlengine/tests/query/test_queryset.py
+++ b/cqlengine/tests/query/test_queryset.py
@@ -20,10 +20,8 @@ from datetime import tzinfo
 from cqlengine import statements
 from cqlengine import operators
 
-
-from cqlengine.connection import get_cluster, get_session
-
-cluster = get_cluster()
+from cqlengine.connection import get_session
+from cqlengine.tests.base import PROTOCOL_VERSION
 
 
 class TzOffset(tzinfo):
@@ -690,7 +688,7 @@ class TestObjectsProperty(BaseQuerySetUsage):
         assert TestModel.objects._result_cache is None
 
 
-@skipUnless(cluster.protocol_version >= 2, "only runs against the cql3 protocol v2.0")
+@skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
 def test_paged_result_handling():
     # addresses #225
     class PagingTest(Model):

--- a/cqlengine/tests/test_ifnotexists.py
+++ b/cqlengine/tests/test_ifnotexists.py
@@ -1,14 +1,12 @@
 from unittest import skipUnless
 from cqlengine.management import sync_table, drop_table, create_keyspace, delete_keyspace
 from cqlengine.tests.base import BaseCassEngTestCase
+from cqlengine.tests.base import PROTOCOL_VERSION
 from cqlengine.models import Model
 from cqlengine.exceptions import LWTException
 from cqlengine import columns, BatchQuery
 from uuid import uuid4
 import mock
-from cqlengine.connection import get_cluster
-
-cluster = get_cluster()
 
 
 class TestIfNotExistsModel(Model):
@@ -43,7 +41,7 @@ class BaseIfNotExistsTest(BaseCassEngTestCase):
 
 class IfNotExistsInsertTests(BaseIfNotExistsTest):
 
-    @skipUnless(cluster.protocol_version >= 2, "only runs against the cql3 protocol v2.0")
+    @skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
     def test_insert_if_not_exists_success(self):
         """ tests that insertion with if_not_exists work as expected """
 
@@ -77,7 +75,7 @@ class IfNotExistsInsertTests(BaseIfNotExistsTest):
         self.assertEquals(tm.count, 9)
         self.assertEquals(tm.text, '111111111111')
 
-    @skipUnless(cluster.protocol_version >= 2, "only runs against the cql3 protocol v2.0")
+    @skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
     def test_batch_insert_if_not_exists_success(self):
         """ tests that batch insertion with if_not_exists work as expected """
 


### PR DESCRIPTION
Moves the logic handling connecting to Cassandra to `cqlengine/tests/__init__.py` into a `setup_package`. Nose runs this code before running any of the tests in the package.

This makes running a subset of the test suite easier. We can still run all tests by running the `bin/tests.py` script (I didn't want to remove it completely in case y'all are in the habit of running tests that way), but we can also run tests using `nosetests` now, like so:

```
$ nosetests
```

And now we can also run a specific test with:

```
$ nosetests cqlengine/tests/test_transaction.py:TestTransaction.test_update_transaction_success
```

One problem I ran into with this PR is with the module-level calls to `get_cluster`. These are executed when tests are _collected_ (i.e. when the test script is imported), which happens before `setup_package` is executed. At that point the connection to Cassandra hasn't been set up yet.

These calls to `get_cluster` existed to get the `protocol_version`, which we needed at import-time. To fix this, removed the module-level calls to `get_cluster`, and instead imported a constant `PROTOCOL_VERSION` which I added to `cqlengine/tests/base.py`.

Let me know if y'all want me to change anything!