### PR TITLE
pip should install the dev requirements when provisioning

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -60,7 +60,7 @@ node cassandraengine inherits basenode {
 
   exec {"install-requirements":
     cwd => "/vagrant",
-    command => "pip install -r requirements.txt",
+    command => "pip install -r requirements-dev.txt",
     require => [Package["python-pip"], Package["python-dev"]]
   }
 }


### PR DESCRIPTION
Changes the `pip` command to install the packages in `requirements-dev.txt` instead of `requirements.txt` so packages like `nose` will be automatically installed when provisioning.