### PR TITLE
skip transaction tests when running cassandra 1.2

### DIFF
--- a/cqlengine/tests/test_transaction.py
+++ b/cqlengine/tests/test_transaction.py
@@ -1,6 +1,9 @@
 __author__ = 'Tim Martin'
+from unittest import skipUnless
+
 from cqlengine.management import sync_table, drop_table
 from cqlengine.tests.base import BaseCassEngTestCase
+from cqlengine.tests.base import CASSANDRA_VERSION
 from cqlengine.models import Model
 from cqlengine.exceptions import LWTException
 from uuid import uuid4
@@ -18,6 +21,7 @@ class TestTransactionModel(Model):
     text = columns.Text(required=False)
 
 
+@skipUnless(CASSANDRA_VERSION >= 20, "transactions only supported on cassandra 2.0 or higher")
 class TestTransaction(BaseCassEngTestCase):
 
     @classmethod


### PR DESCRIPTION
Fixes #308. This should fix the Travis builds with C* 1.2.

My assumption here is that transactions aren't supported for 1.2, so we shouldn't test transactions. It's possible this isn't a valid assumption, though.