### PR TITLE
fix issue

### DIFF
--- a/cqlengine/exceptions.py
+++ b/cqlengine/exceptions.py
@@ -5,3 +5,4 @@ class ValidationError(CQLEngineException): pass
 
 class UndefinedKeyspaceException(CQLEngineException): pass
 class LWTException(CQLEngineException): pass
+class IfNotExistsWithCounterColumn(CQLEngineException): pass

--- a/cqlengine/query.py
+++ b/cqlengine/query.py
@@ -7,7 +7,12 @@ from cqlengine.columns import Counter, List, Set
 
 from .connection import execute, NOT_SET
 
-from cqlengine.exceptions import CQLEngineException, ValidationError, LWTException
+from cqlengine.exceptions import (
+    CQLEngineException,
+    ValidationError,
+    LWTException,
+    IfNotExistsWithCounterColumn
+    )
 from cqlengine.functions import Token, BaseQueryFunction, QueryValue, UnicodeMixin
 
 #CQL 3 reference:
@@ -784,6 +789,8 @@ class ModelQuerySet(AbstractQuerySet):
         return clone
 
     def if_not_exists(self):
+        if self.model._has_counter:
+            raise IfNotExistsWithCounterColumn('if_not_exists would be ignored on table with counter columns')
         clone = copy.deepcopy(self)
         clone._if_not_exists = True
         return clone

--- a/cqlengine/tests/test_ifnotexists.py
+++ b/cqlengine/tests/test_ifnotexists.py
@@ -3,7 +3,7 @@ from cqlengine.management import sync_table, drop_table, create_keyspace, delete
 from cqlengine.tests.base import BaseCassEngTestCase
 from cqlengine.tests.base import PROTOCOL_VERSION
 from cqlengine.models import Model
-from cqlengine.exceptions import LWTException
+from cqlengine.exceptions import LWTException, IfNotExistsWithCounterColumn
 from cqlengine import columns, BatchQuery
 from uuid import uuid4
 import mock
@@ -16,6 +16,14 @@ class TestIfNotExistsModel(Model):
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
     text    = columns.Text(required=False)
+
+
+class TestIfNotExistsWithCounterModel(Model):
+
+    __keyspace__ = 'cqlengine_test_lwt'
+
+    id      = columns.UUID(primary_key=True, default=lambda:uuid4())
+    likes   = columns.Counter()
 
 
 class BaseIfNotExistsTest(BaseCassEngTestCase):
@@ -36,6 +44,20 @@ class BaseIfNotExistsTest(BaseCassEngTestCase):
     def tearDownClass(cls):
         super(BaseCassEngTestCase, cls).tearDownClass()
         drop_table(TestIfNotExistsModel)
+        delete_keyspace(TestIfNotExistsModel.__keyspace__)
+
+
+class BaseIfNotExistsWithCounterTest(BaseCassEngTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        create_keyspace(TestIfNotExistsModel.__keyspace__, replication_factor=1)
+        sync_table(TestIfNotExistsWithCounterModel)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(BaseCassEngTestCase, cls).tearDownClass()
+        drop_table(TestIfNotExistsWithCounterModel)
         delete_keyspace(TestIfNotExistsModel.__keyspace__)
 
 
@@ -173,4 +195,17 @@ class IfNotExistsInstanceTest(BaseIfNotExistsTest):
         query = m.call_args[0][0].query_string
         self.assertNotIn("IF NOT EXIST", query)
 
+
+class IfNotExistWithCounterTest(BaseIfNotExistsWithCounterTest):
+
+    def test_instance_raise_exception(self):
+        """ make sure exception is raised when calling
+        if_not_exists on table with counter column
+        """
+        id = uuid4()
+
+        self.assertRaises(
+            IfNotExistsWithCounterColumn,
+            TestIfNotExistsWithCounterModel.if_not_exists
+        )
 


### PR DESCRIPTION
https://github.com/cqlengine/cqlengine/issues/302

once calling if_not_exists on a table with counter column, an exception
would be raised. if_not_exists is only valid on INSERT command, and there is no INSERT for tables with counter columns.