### PR TITLE
raise exception when if_not_exists is not capable.

### DIFF
--- a/cqlengine/exceptions.py
+++ b/cqlengine/exceptions.py
@@ -5,3 +5,4 @@ class ValidationError(CQLEngineException): pass
 
 class UndefinedKeyspaceException(CQLEngineException): pass
 class LWTException(CQLEngineException): pass
+class IfNotExistsWithCounterColumn(CQLEngineException): pass

--- a/cqlengine/management.py
+++ b/cqlengine/management.py
@@ -18,7 +18,7 @@ from cqlengine.models import Model
 # system keyspaces
 schema_columnfamilies = NamedTable('system', 'schema_columnfamilies')
 
-def create_keyspace(name, strategy_class='SimpleStrategy', replication_factor=3, durable_writes=True, **replication_values):
+def create_keyspace(name, strategy_class, replication_factor, durable_writes=True, **replication_values):
     """
     creates a keyspace
 
@@ -62,7 +62,7 @@ def delete_keyspace(name):
 def create_table(model, create_missing_keyspace=True):
     raise CQLEngineException("create_table is deprecated, please use sync_table")
 
-def sync_table(model, create_missing_keyspace=True):
+def sync_table(model):
     """
     Inspects the model and creates / updates the corresponding table and columns.
 
@@ -86,9 +86,6 @@ def sync_table(model, create_missing_keyspace=True):
     raw_cf_name = model.column_family_name(include_keyspace=False)
 
     ks_name = model._get_keyspace()
-    #create missing keyspace
-    if create_missing_keyspace:
-        create_keyspace(ks_name)
 
     cluster = get_cluster()
 

--- a/cqlengine/query.py
+++ b/cqlengine/query.py
@@ -7,7 +7,7 @@ from cqlengine.columns import Counter, List, Set
 
 from .connection import execute, NOT_SET
 
-from cqlengine.exceptions import CQLEngineException, ValidationError, LWTException
+from cqlengine.exceptions import CQLEngineException, ValidationError, LWTException, IfNotExistsWithCounterColumn
 from cqlengine.functions import Token, BaseQueryFunction, QueryValue, UnicodeMixin
 
 #CQL 3 reference:
@@ -784,6 +784,8 @@ class ModelQuerySet(AbstractQuerySet):
         return clone
 
     def if_not_exists(self):
+        if self.model._has_counter:
+            raise IfNotExistsWithCounterColumn('if_not_exists would be ignored on table with counter columns')
         clone = copy.deepcopy(self)
         clone._if_not_exists = True
         return clone

--- a/cqlengine/query.py
+++ b/cqlengine/query.py
@@ -785,7 +785,7 @@ class ModelQuerySet(AbstractQuerySet):
 
     def if_not_exists(self):
         if self.model._has_counter:
-            raise IfNotExistsWithCounterColumn('if_not_exists would be ignored on table with counter columns')
+            raise IfNotExistsWithCounterColumn('if_not_exists cannot be used with tables containing columns')
         clone = copy.deepcopy(self)
         clone._if_not_exists = True
         return clone

--- a/cqlengine/tests/__init__.py
+++ b/cqlengine/tests/__init__.py
@@ -1,6 +1,9 @@
 import os
 
+
 from cqlengine import connection
+from cqlengine.management import create_keyspace
+
 
 def setup_package():
     try:
@@ -23,3 +26,5 @@ def setup_package():
     connection.setup([CASSANDRA_TEST_HOST],
                       protocol_version=protocol_version,
                       default_keyspace='cqlengine_test')
+
+    create_keyspace("cqlengine_test", replication_factor=1, strategy_class="SimpleStrategy")

--- a/cqlengine/tests/columns/test_container_columns.py
+++ b/cqlengine/tests/columns/test_container_columns.py
@@ -10,7 +10,7 @@ from cqlengine.tests.base import BaseCassEngTestCase
 
 
 class TestSetModel(Model):
-    __keyspace__ = 'test'
+
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     int_set = columns.Set(columns.Integer, required=False)
@@ -163,7 +163,7 @@ class TestSetColumn(BaseCassEngTestCase):
 
 
 class TestListModel(Model):
-    __keyspace__ = 'test'
+
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     int_list = columns.List(columns.Integer, required=False)
@@ -309,7 +309,7 @@ class TestListColumn(BaseCassEngTestCase):
         assert m3.int_list == []
 
 class TestMapModel(Model):
-    __keyspace__ = 'test'
+
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     int_map = columns.Map(columns.Integer, columns.UUID, required=False)
@@ -509,7 +509,7 @@ class TestMapColumn(BaseCassEngTestCase):
 
 
 class TestCamelMapModel(Model):
-    __keyspace__ = 'test'
+
 
     partition = columns.UUID(primary_key=True, default=uuid4)
     camelMap = columns.Map(columns.Text, columns.Integer, required=False)

--- a/cqlengine/tests/columns/test_counter_column.py
+++ b/cqlengine/tests/columns/test_counter_column.py
@@ -8,7 +8,7 @@ from cqlengine.tests.base import BaseCassEngTestCase
 
 
 class TestCounterModel(Model):
-    __keyspace__ = 'test'
+
     partition = columns.UUID(primary_key=True, default=uuid4)
     cluster = columns.UUID(primary_key=True, default=uuid4)
     counter = columns.Counter()

--- a/cqlengine/tests/columns/test_static_column.py
+++ b/cqlengine/tests/columns/test_static_column.py
@@ -9,7 +9,7 @@ from cqlengine.tests.base import CASSANDRA_VERSION, PROTOCOL_VERSION
 
 
 class TestStaticModel(Model):
-    __keyspace__ = 'test'
+
     partition = columns.UUID(primary_key=True, default=uuid4)
     cluster = columns.UUID(primary_key=True, default=uuid4)
     static = columns.Text(static=True)
@@ -35,15 +35,15 @@ class TestStaticColumn(BaseCassEngTestCase):
         """ Tests that updates on both static and non-static columns work as intended """
         instance = TestStaticModel.create()
         instance.static = "it's shared"
-        instance.text = "some text" 
+        instance.text = "some text"
         instance.save()
-        
+
         u = TestStaticModel.get(partition=instance.partition)
         u.static = "it's still shared"
         u.text = "another text"
         u.update()
         actual = TestStaticModel.get(partition=u.partition)
-        
+
         assert actual.static == "it's still shared"
 
     @skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
@@ -51,12 +51,12 @@ class TestStaticColumn(BaseCassEngTestCase):
         """ Tests that updates on static only column work as intended """
         instance = TestStaticModel.create()
         instance.static = "it's shared"
-        instance.text = "some text" 
+        instance.text = "some text"
         instance.save()
-        
+
         u = TestStaticModel.get(partition=instance.partition)
         u.static = "it's still shared"
         u.update()
-        actual = TestStaticModel.get(partition=u.partition)        
+        actual = TestStaticModel.get(partition=u.partition)
         assert actual.static == "it's still shared"
 

--- a/cqlengine/tests/columns/test_validation.py
+++ b/cqlengine/tests/columns/test_validation.py
@@ -33,7 +33,7 @@ from cqlengine.models import Model
 
 class TestDatetime(BaseCassEngTestCase):
     class DatetimeTest(Model):
-        __keyspace__ = 'test'
+
         test_id = Integer(primary_key=True)
         created_at = DateTime()
 
@@ -82,7 +82,7 @@ class TestDatetime(BaseCassEngTestCase):
 
 class TestBoolDefault(BaseCassEngTestCase):
     class BoolDefaultValueTest(Model):
-        __keyspace__ = 'test'
+
         test_id = Integer(primary_key=True)
         stuff = Boolean(default=True)
 
@@ -99,7 +99,7 @@ class TestBoolDefault(BaseCassEngTestCase):
 
 class TestBoolValidation(BaseCassEngTestCase):
     class BoolValidationTest(Model):
-        __keyspace__ = 'test'
+
         test_id = Integer(primary_key=True)
         bool_column = Boolean()
 
@@ -116,7 +116,7 @@ class TestBoolValidation(BaseCassEngTestCase):
 
 class TestVarInt(BaseCassEngTestCase):
     class VarIntTest(Model):
-        __keyspace__ = 'test'
+
         test_id = Integer(primary_key=True)
         bignum = VarInt(primary_key=True)
 
@@ -141,7 +141,7 @@ class TestVarInt(BaseCassEngTestCase):
 
 class TestDate(BaseCassEngTestCase):
     class DateTest(Model):
-        __keyspace__ = 'test'
+
         test_id = Integer(primary_key=True)
         created_at = Date()
 
@@ -180,7 +180,7 @@ class TestDate(BaseCassEngTestCase):
 
 class TestDecimal(BaseCassEngTestCase):
     class DecimalTest(Model):
-        __keyspace__ = 'test'
+
         test_id = Integer(primary_key=True)
         dec_val = Decimal()
 
@@ -205,7 +205,7 @@ class TestDecimal(BaseCassEngTestCase):
 
 class TestUUID(BaseCassEngTestCase):
     class UUIDTest(Model):
-        __keyspace__ = 'test'
+
         test_id = Integer(primary_key=True)
         a_uuid = UUID(default=uuid4())
 
@@ -233,7 +233,7 @@ class TestUUID(BaseCassEngTestCase):
 
 class TestTimeUUID(BaseCassEngTestCase):
     class TimeUUIDTest(Model):
-        __keyspace__ = 'test'
+
         test_id = Integer(primary_key=True)
         timeuuid = TimeUUID(default=uuid1())
 
@@ -259,7 +259,7 @@ class TestTimeUUID(BaseCassEngTestCase):
 
 class TestInteger(BaseCassEngTestCase):
     class IntegerTest(Model):
-        __keyspace__ = 'test'
+
         test_id = UUID(primary_key=True, default=lambda:uuid4())
         value   = Integer(default=0, required=True)
 
@@ -270,7 +270,7 @@ class TestInteger(BaseCassEngTestCase):
 
 class TestBigInt(BaseCassEngTestCase):
     class BigIntTest(Model):
-        __keyspace__ = 'test'
+
         test_id = UUID(primary_key=True, default=lambda:uuid4())
         value   = BigInt(default=0, required=True)
 
@@ -328,7 +328,7 @@ class TestText(BaseCassEngTestCase):
 
 class TestExtraFieldsRaiseException(BaseCassEngTestCase):
     class TestModel(Model):
-        __keyspace__ = 'test'
+
         id = UUID(primary_key=True, default=uuid4)
 
     def test_extra_field(self):
@@ -337,7 +337,7 @@ class TestExtraFieldsRaiseException(BaseCassEngTestCase):
 
 class TestPythonDoesntDieWhenExtraFieldIsInCassandra(BaseCassEngTestCase):
     class TestModel(Model):
-        __keyspace__ = 'test'
+
         __table_name__ = 'alter_doesnt_break_running_app'
         id = UUID(primary_key=True, default=uuid4)
 

--- a/cqlengine/tests/columns/test_value_io.py
+++ b/cqlengine/tests/columns/test_value_io.py
@@ -41,7 +41,7 @@ class BaseColumnIOTest(BaseCassEngTestCase):
 
         # create a table with the given column
         class IOTestModel(Model):
-            __keyspace__ = 'test'
+
             table_name = cls.column.db_type + "_io_test_model_{}".format(uuid4().hex[:8])
             pkey = cls.column(primary_key=True)
             data = cls.column()

--- a/cqlengine/tests/management/test_compaction_settings.py
+++ b/cqlengine/tests/management/test_compaction_settings.py
@@ -9,7 +9,7 @@ from cqlengine.tests.base import BaseCassEngTestCase
 
 
 class CompactionModel(Model):
-    __keyspace__ = 'test'
+
     __compaction__ = None
     cid = columns.UUID(primary_key=True)
     name = columns.Text()
@@ -74,7 +74,7 @@ class LeveledCompactionTest(BaseCompactionTest):
 
 
 class LeveledcompactionTestTable(Model):
-    __keyspace__ = 'test'
+
     __compaction__ = LeveledCompactionStrategy
     __compaction_sstable_size_in_mb__ = 64
 
@@ -96,7 +96,7 @@ class AlterTableTest(BaseCassEngTestCase):
         from cqlengine.management import update_compaction
 
         class LeveledCompactionChangesDetectionTest(Model):
-            __keyspace__ = 'test'
+
             __compaction__ = LeveledCompactionStrategy
             __compaction_sstable_size_in_mb__ = 160
             __compaction_tombstone_threshold__ = 0.125
@@ -113,7 +113,7 @@ class AlterTableTest(BaseCassEngTestCase):
         from cqlengine.management import update_compaction
 
         class SizeTieredCompactionChangesDetectionTest(Model):
-            __keyspace__ = 'test'
+
             __compaction__ = SizeTieredCompactionStrategy
             __compaction_bucket_high__ = 20
             __compaction_bucket_low__ = 10
@@ -146,7 +146,7 @@ class AlterTableTest(BaseCassEngTestCase):
     def test_alter_options(self):
 
         class AlterTable(Model):
-            __keyspace__ = 'test'
+
             __compaction__ = LeveledCompactionStrategy
             __compaction_sstable_size_in_mb__ = 64
 
@@ -163,7 +163,7 @@ class AlterTableTest(BaseCassEngTestCase):
 class EmptyCompactionTest(BaseCassEngTestCase):
     def test_empty_compaction(self):
         class EmptyCompactionModel(Model):
-            __keyspace__ = 'test'
+
             __compaction__ = None
             cid = columns.UUID(primary_key=True)
             name = columns.Text()
@@ -173,14 +173,14 @@ class EmptyCompactionTest(BaseCassEngTestCase):
 
 
 class CompactionLeveledStrategyModel(Model):
-    __keyspace__ = 'test'
+
     __compaction__ = LeveledCompactionStrategy
     cid = columns.UUID(primary_key=True)
     name = columns.Text()
 
 
 class CompactionSizeTieredModel(Model):
-    __keyspace__ = 'test'
+
     __compaction__ = SizeTieredCompactionStrategy
     cid = columns.UUID(primary_key=True)
     name = columns.Text()
@@ -191,7 +191,7 @@ class OptionsTest(BaseCassEngTestCase):
 
     def test_all_size_tiered_options(self):
         class AllSizeTieredOptionsModel(Model):
-            __keyspace__ = 'test'
+
             __compaction__ = SizeTieredCompactionStrategy
             __compaction_bucket_low__ = .3
             __compaction_bucket_high__ = 2
@@ -220,7 +220,7 @@ class OptionsTest(BaseCassEngTestCase):
     def test_all_leveled_options(self):
 
         class AllLeveledOptionsModel(Model):
-            __keyspace__ = 'test'
+
             __compaction__ = LeveledCompactionStrategy
             __compaction_sstable_size_in_mb__ = 64
 

--- a/cqlengine/tests/management/test_management.py
+++ b/cqlengine/tests/management/test_management.py
@@ -14,7 +14,7 @@ from unittest import skipUnless
 
 class CreateKeyspaceTest(BaseCassEngTestCase):
     def test_create_succeeeds(self):
-        management.create_keyspace('test_keyspace')
+        management.create_keyspace('test_keyspace', strategy_class="SimpleStrategy", replication_factor=1)
         management.delete_keyspace('test_keyspace')
 
 class DeleteTableTest(BaseCassEngTestCase):
@@ -29,19 +29,19 @@ class DeleteTableTest(BaseCassEngTestCase):
         drop_table(TestModel)
 
 class LowercaseKeyModel(Model):
-    __keyspace__ = 'test'
+
     first_key = columns.Integer(primary_key=True)
     second_key = columns.Integer(primary_key=True)
     some_data = columns.Text()
 
 class CapitalizedKeyModel(Model):
-    __keyspace__ = 'test'
+
     firstKey = columns.Integer(primary_key=True)
     secondKey = columns.Integer(primary_key=True)
     someData = columns.Text()
 
 class PrimaryKeysOnlyModel(Model):
-    __keyspace__ = 'test'
+
     __compaction__ = LeveledCompactionStrategy
 
     first_ey = columns.Integer(primary_key=True)
@@ -60,14 +60,14 @@ class CapitalizedKeyTest(BaseCassEngTestCase):
 
 
 class FirstModel(Model):
-    __keyspace__ = 'test'
+
     __table_name__ = 'first_model'
     first_key = columns.UUID(primary_key=True)
     second_key = columns.UUID()
     third_key = columns.Text()
 
 class SecondModel(Model):
-    __keyspace__ = 'test'
+
     __table_name__ = 'first_model'
     first_key = columns.UUID(primary_key=True)
     second_key = columns.UUID()
@@ -75,7 +75,7 @@ class SecondModel(Model):
     fourth_key = columns.Text()
 
 class ThirdModel(Model):
-    __keyspace__ = 'test'
+
     __table_name__ = 'first_model'
     first_key = columns.UUID(primary_key=True)
     second_key = columns.UUID()
@@ -84,7 +84,7 @@ class ThirdModel(Model):
     blah = columns.Map(columns.Text, columns.Text)
 
 class FourthModel(Model):
-    __keyspace__ = 'test'
+
     __table_name__ = 'first_model'
     first_key = columns.UUID(primary_key=True)
     second_key = columns.UUID()
@@ -118,7 +118,7 @@ class AddColumnTest(BaseCassEngTestCase):
 
 
 class ModelWithTableProperties(Model):
-    __keyspace__ = 'test'
+
     # Set random table properties
     __bloom_filter_fp_chance__ = 0.76328
     __caching__ = CACHING_ALL

--- a/cqlengine/tests/model/test_class_construction.py
+++ b/cqlengine/tests/model/test_class_construction.py
@@ -20,7 +20,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         """
 
         class TestModel(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             text = columns.Text()
 
@@ -42,7 +42,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         -the db_map allows columns
         """
         class WildDBNames(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             content = columns.Text(db_field='words_and_whatnot')
             numbers = columns.Integer(db_field='integers_etc')
@@ -67,7 +67,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         """
 
         class Stuff(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             words = columns.Text()
             content = columns.Text()
@@ -78,7 +78,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
     def test_exception_raised_when_creating_class_without_pk(self):
         with self.assertRaises(ModelDefinitionException):
             class TestModel(Model):
-                __keyspace__ = 'test'
+
                 count   = columns.Integer()
                 text    = columns.Text(required=False)
 
@@ -88,7 +88,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         Tests that instance value managers are isolated from other instances
         """
         class Stuff(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             num = columns.Integer()
 
@@ -104,7 +104,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         Tests that fields defined on the super class are inherited properly
         """
         class TestModel(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             text = columns.Text()
 
@@ -117,7 +117,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
     def test_column_family_name_generation(self):
         """ Tests that auto column family name generation works as expected """
         class TestModel(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             text = columns.Text()
 
@@ -153,7 +153,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         Test compound partition key definition
         """
         class ModelWithPartitionKeys(cqlengine.Model):
-            __keyspace__ = 'test'
+
             id = columns.UUID(primary_key=True, default=lambda:uuid4())
             c1 = cqlengine.Text(primary_key=True)
             p1 = cqlengine.Text(partition_key=True)
@@ -175,7 +175,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
     def test_del_attribute_is_assigned_properly(self):
         """ Tests that columns that can be deleted have the del attribute """
         class DelModel(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             key = columns.Integer(primary_key=True)
             data = columns.Integer(required=False)
@@ -189,11 +189,11 @@ class TestModelClassFunction(BaseCassEngTestCase):
         """ Tests that DoesNotExist exceptions are not the same exception between models """
 
         class Model1(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
 
         class Model2(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
 
         try:
@@ -207,7 +207,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
     def test_does_not_exist_inherits_from_superclass(self):
         """ Tests that a DoesNotExist exception can be caught by it's parent class DoesNotExist """
         class Model1(Model):
-            __keyspace__ = 'test'
+
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
 
         class Model2(Model1):
@@ -244,14 +244,14 @@ class TestManualTableNaming(BaseCassEngTestCase):
 
 class AbstractModel(Model):
     __abstract__ = True
-    __keyspace__ = 'test'
+
 
 class ConcreteModel(AbstractModel):
     pkey = columns.Integer(primary_key=True)
     data = columns.Integer()
 
 class AbstractModelWithCol(Model):
-    __keyspace__ = 'test'
+
     __abstract__ = True
     pkey = columns.Integer(primary_key=True)
 
@@ -260,7 +260,7 @@ class ConcreteModelWithCol(AbstractModelWithCol):
 
 class AbstractModelWithFullCols(Model):
     __abstract__ = True
-    __keyspace__ = 'test'
+
     pkey = columns.Integer(primary_key=True)
     data = columns.Integer()
 
@@ -333,7 +333,7 @@ class TestCustomQuerySet(BaseCassEngTestCase):
 
         class CQModel(Model):
             __queryset__ = QSet
-            __keyspace__ = 'test'
+
             part = columns.UUID(primary_key=True)
             data = columns.Text()
 
@@ -347,7 +347,7 @@ class TestCustomQuerySet(BaseCassEngTestCase):
                 raise self.TestException
 
         class CDQModel(Model):
-            __keyspace__ = 'test'
+
             __dmlquery__ = DMLQ
             part = columns.UUID(primary_key=True)
             data = columns.Text()

--- a/cqlengine/tests/model/test_equality_operations.py
+++ b/cqlengine/tests/model/test_equality_operations.py
@@ -8,7 +8,7 @@ from cqlengine.models import Model
 from cqlengine import columns
 
 class TestModel(Model):
-    __keyspace__ = 'test'
+
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
     text    = columns.Text(required=False)

--- a/cqlengine/tests/model/test_model.py
+++ b/cqlengine/tests/model/test_model.py
@@ -10,7 +10,7 @@ class TestModel(TestCase):
     def test_instance_equality(self):
         """ tests the model equality functionality """
         class EqualityModel(Model):
-            __keyspace__ = 'test'
+
             pk = columns.Integer(primary_key=True)
 
         m0 = EqualityModel(pk=0)
@@ -22,11 +22,11 @@ class TestModel(TestCase):
     def test_model_equality(self):
         """ tests the model equality functionality """
         class EqualityModel0(Model):
-            __keyspace__ = 'test'
+
             pk = columns.Integer(primary_key=True)
 
         class EqualityModel1(Model):
-            __keyspace__ = 'test'
+
             kk = columns.Integer(primary_key=True)
 
         m0 = EqualityModel0(pk=0)
@@ -43,7 +43,7 @@ class BuiltInAttributeConflictTest(TestCase):
         """should raise exception when model defines column that conflicts with built-in attribute"""
         with self.assertRaises(ModelDefinitionException):
             class IllegalTimestampColumnModel(Model):
-                __keyspace__ = 'test'
+
                 my_primary_key = columns.Integer(primary_key=True)
                 timestamp = columns.BigInt()
 
@@ -51,7 +51,7 @@ class BuiltInAttributeConflictTest(TestCase):
         """should raise exception when model defines column that conflicts with built-in method"""
         with self.assertRaises(ModelDefinitionException):
             class IllegalFilterColumnModel(Model):
-                __keyspace__ = 'test'
+
                 my_primary_key = columns.Integer(primary_key=True)
                 filter = columns.Text()
 

--- a/cqlengine/tests/model/test_model_io.py
+++ b/cqlengine/tests/model/test_model_io.py
@@ -11,14 +11,14 @@ from cqlengine.models import Model
 from cqlengine import columns
 
 class TestModel(Model):
-    __keyspace__ = 'test'
+
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
     text    = columns.Text(required=False)
     a_bool  = columns.Boolean(default=False)
 
 class TestModel(Model):
-    __keyspace__ = 'test'
+
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
     text    = columns.Text(required=False)
@@ -118,7 +118,7 @@ class TestModelIO(BaseCassEngTestCase):
 
 
 class TestMultiKeyModel(Model):
-    __keyspace__ = 'test'
+
     partition   = columns.Integer(primary_key=True)
     cluster     = columns.Integer(primary_key=True)
     count       = columns.Integer(required=False)
@@ -244,7 +244,7 @@ class TestCanUpdate(BaseCassEngTestCase):
 
 
 class IndexDefinitionModel(Model):
-    __keyspace__ = 'test'
+
     key     = columns.UUID(primary_key=True)
     val     = columns.Text(index=True)
 
@@ -255,7 +255,7 @@ class TestIndexedColumnDefinition(BaseCassEngTestCase):
         sync_table(IndexDefinitionModel)
 
 class ReservedWordModel(Model):
-    __keyspace__ = 'test'
+
     token   = columns.Text(primary_key=True)
     insert  = columns.Integer(index=True)
 
@@ -276,7 +276,7 @@ class TestQueryQuoting(BaseCassEngTestCase):
 
 
 class TestQueryModel(Model):
-    __keyspace__ = 'test'
+
     test_id = columns.UUID(primary_key=True, default=uuid4)
     date = columns.Date(primary_key=True)
     description = columns.Text()
@@ -311,7 +311,7 @@ class TestQuerying(BaseCassEngTestCase):
 
 def test_none_filter_fails():
     class NoneFilterModel(Model):
-        __keyspace__ = 'test'
+
         pk = columns.Integer(primary_key=True)
         v = columns.Integer()
     sync_table(NoneFilterModel)

--- a/cqlengine/tests/model/test_polymorphism.py
+++ b/cqlengine/tests/model/test_polymorphism.py
@@ -14,7 +14,7 @@ class TestPolymorphicClassConstruction(BaseCassEngTestCase):
         """ Tests that defining a model with more than one polymorphic key fails """
         with self.assertRaises(models.ModelDefinitionException):
             class M(models.Model):
-                __keyspace__ = 'test'
+
                 partition = columns.Integer(primary_key=True)
                 type1 = columns.Integer(polymorphic_key=True)
                 type2 = columns.Integer(polymorphic_key=True)
@@ -22,7 +22,7 @@ class TestPolymorphicClassConstruction(BaseCassEngTestCase):
     def test_polymorphic_key_inheritance(self):
         """ Tests that polymorphic_key attribute is not inherited """
         class Base(models.Model):
-            __keyspace__ = 'test'
+
             partition = columns.Integer(primary_key=True)
             type1 = columns.Integer(polymorphic_key=True)
 
@@ -37,7 +37,7 @@ class TestPolymorphicClassConstruction(BaseCassEngTestCase):
     def test_polymorphic_metaclass(self):
         """ Tests that the model meta class configures polymorphic models properly """
         class Base(models.Model):
-            __keyspace__ = 'test'
+
             partition = columns.Integer(primary_key=True)
             type1 = columns.Integer(polymorphic_key=True)
 
@@ -58,7 +58,7 @@ class TestPolymorphicClassConstruction(BaseCassEngTestCase):
 
     def test_table_names_are_inherited_from_poly_base(self):
         class Base(models.Model):
-            __keyspace__ = 'test'
+
             partition = columns.Integer(primary_key=True)
             type1 = columns.Integer(polymorphic_key=True)
 
@@ -70,13 +70,13 @@ class TestPolymorphicClassConstruction(BaseCassEngTestCase):
     def test_collection_columns_cant_be_polymorphic_keys(self):
         with self.assertRaises(models.ModelDefinitionException):
             class Base(models.Model):
-                __keyspace__ = 'test'
+
                 partition = columns.Integer(primary_key=True)
                 type1 = columns.Set(columns.Integer, polymorphic_key=True)
 
 
 class PolyBase(models.Model):
-    __keyspace__ = 'test'
+
     partition = columns.UUID(primary_key=True, default=uuid.uuid4)
     row_type = columns.Integer(polymorphic_key=True)
 
@@ -143,7 +143,7 @@ class TestPolymorphicModel(BaseCassEngTestCase):
 
 
 class UnindexedPolyBase(models.Model):
-    __keyspace__ = 'test'
+
     partition = columns.UUID(primary_key=True, default=uuid.uuid4)
     cluster = columns.UUID(primary_key=True, default=uuid.uuid4)
     row_type = columns.Integer(polymorphic_key=True)
@@ -201,7 +201,7 @@ class TestUnindexedPolymorphicQuery(BaseCassEngTestCase):
 
 
 class IndexedPolyBase(models.Model):
-    __keyspace__ = 'test'
+
     partition = columns.UUID(primary_key=True, default=uuid.uuid4)
     cluster = columns.UUID(primary_key=True, default=uuid.uuid4)
     row_type = columns.Integer(polymorphic_key=True, index=True)

--- a/cqlengine/tests/model/test_updates.py
+++ b/cqlengine/tests/model/test_updates.py
@@ -10,7 +10,7 @@ from cqlengine.management import sync_table, drop_table
 
 
 class TestUpdateModel(Model):
-    __keyspace__ = 'test'
+
     partition   = columns.UUID(primary_key=True, default=uuid4)
     cluster     = columns.UUID(primary_key=True, default=uuid4)
     count       = columns.Integer(required=False)

--- a/cqlengine/tests/model/test_value_lists.py
+++ b/cqlengine/tests/model/test_value_lists.py
@@ -8,12 +8,12 @@ from cqlengine import columns
 
 
 class TestModel(Model):
-    __keyspace__ = 'test'
+
     id = columns.Integer(primary_key=True)
     clustering_key = columns.Integer(primary_key=True, clustering_order='desc')
 
 class TestClusteringComplexModel(Model):
-    __keyspace__ = 'test'
+
     id = columns.Integer(primary_key=True)
     clustering_key = columns.Integer(primary_key=True, clustering_order='desc')
     some_value = columns.Integer()

--- a/cqlengine/tests/query/test_batch_query.py
+++ b/cqlengine/tests/query/test_batch_query.py
@@ -12,14 +12,14 @@ import mock
 
 
 class TestMultiKeyModel(Model):
-    __keyspace__ = 'test'
+
     partition   = columns.Integer(primary_key=True)
     cluster     = columns.Integer(primary_key=True)
     count       = columns.Integer(required=False)
     text        = columns.Text(required=False)
 
 class BatchQueryLogModel(Model):
-    __keyspace__ = 'test'
+
     # simple k/v table
     k = columns.Integer(primary_key=True)
     v = columns.Integer()
@@ -170,7 +170,7 @@ class BatchQueryTests(BaseCassEngTestCase):
             pass
 
         obj = BatchQueryLogModel.objects(k=2)
-        
+
         # should be 0 because the batch should not execute
         self.assertEqual(0, len(obj))
 

--- a/cqlengine/tests/query/test_datetime_queries.py
+++ b/cqlengine/tests/query/test_datetime_queries.py
@@ -11,7 +11,7 @@ from cqlengine import columns
 from cqlengine import query
 
 class DateTimeQueryTestModel(Model):
-    __keyspace__ = 'test'
+
     user        = columns.Integer(primary_key=True)
     day         = columns.DateTime(primary_key=True)
     data        = columns.Text()

--- a/cqlengine/tests/query/test_queryoperators.py
+++ b/cqlengine/tests/query/test_queryoperators.py
@@ -39,7 +39,7 @@ class TestQuerySetOperation(BaseCassEngTestCase):
 
 
 class TokenTestModel(Model):
-    __keyspace__ = 'test'
+
     key = columns.Integer(primary_key=True)
     val = columns.Integer()
 
@@ -75,7 +75,7 @@ class TestTokenFunction(BaseCassEngTestCase):
     def test_compound_pk_token_function(self):
 
         class TestModel(Model):
-            __keyspace__ = 'test'
+
             p1 = columns.Text(partition_key=True)
             p2 = columns.Text(partition_key=True)
 

--- a/cqlengine/tests/query/test_queryset.py
+++ b/cqlengine/tests/query/test_queryset.py
@@ -43,7 +43,7 @@ class TzOffset(tzinfo):
 
 
 class TestModel(Model):
-    __keyspace__ = 'test'
+
     test_id = columns.Integer(primary_key=True)
     attempt_id = columns.Integer(primary_key=True)
     description = columns.Text()
@@ -52,7 +52,7 @@ class TestModel(Model):
 
 
 class IndexedTestModel(Model):
-    __keyspace__ = 'test'
+
     test_id = columns.Integer(primary_key=True)
     attempt_id = columns.Integer(index=True)
     description = columns.Text()
@@ -61,7 +61,7 @@ class IndexedTestModel(Model):
 
 
 class TestMultiClusteringModel(Model):
-    __keyspace__ = 'test'
+
     one = columns.Integer(primary_key=True)
     two = columns.Integer(primary_key=True)
     three = columns.Integer(primary_key=True)
@@ -380,7 +380,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
 
 def test_non_quality_filtering():
     class NonEqualityFilteringModel(Model):
-        __keyspace__ = 'test'
+
         example_id = columns.UUID(primary_key=True, default=uuid.uuid4)
         sequence_id = columns.Integer(primary_key=True)  # sequence_id is a clustering key
         example_type = columns.Integer(index=True)
@@ -550,7 +550,7 @@ class TestQuerySetConnectionHandling(BaseQuerySetUsage):
 
 
 class TimeUUIDQueryModel(Model):
-    __keyspace__ = 'test'
+
     partition = columns.UUID(primary_key=True)
     time = columns.TimeUUID(primary_key=True)
     data = columns.Text(required=False)

--- a/cqlengine/tests/query/test_updates.py
+++ b/cqlengine/tests/query/test_updates.py
@@ -9,7 +9,7 @@ from cqlengine import columns
 
 
 class TestQueryUpdateModel(Model):
-    __keyspace__ = 'test'
+
     partition   = columns.UUID(primary_key=True, default=uuid4)
     cluster     = columns.Integer(primary_key=True)
     count       = columns.Integer(required=False)

--- a/cqlengine/tests/test_batch_query.py
+++ b/cqlengine/tests/test_batch_query.py
@@ -11,7 +11,7 @@ from cqlengine.query import BatchQuery
 from cqlengine.tests.base import BaseCassEngTestCase
 
 class TestMultiKeyModel(Model):
-    __keyspace__ = 'test'
+
     partition   = columns.Integer(primary_key=True)
     cluster     = columns.Integer(primary_key=True)
     count       = columns.Integer(required=False)

--- a/cqlengine/tests/test_consistency.py
+++ b/cqlengine/tests/test_consistency.py
@@ -7,7 +7,7 @@ import mock
 from cqlengine import ALL, BatchQuery
 
 class TestConsistencyModel(Model):
-    __keyspace__ = 'test'
+
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
     text    = columns.Text(required=False)

--- a/cqlengine/tests/test_ifnotexists.py
+++ b/cqlengine/tests/test_ifnotexists.py
@@ -11,8 +11,6 @@ import mock
 
 class TestIfNotExistsModel(Model):
 
-    __keyspace__ = 'cqlengine_test_lwt'
-
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
     text    = columns.Text(required=False)
@@ -29,14 +27,12 @@ class BaseIfNotExistsTest(BaseCassEngTestCase):
         is 3 and one node only. Therefore I have create a new keyspace with
         replica_factor:1.
         """
-        create_keyspace(TestIfNotExistsModel.__keyspace__, replication_factor=1)
         sync_table(TestIfNotExistsModel)
 
     @classmethod
     def tearDownClass(cls):
         super(BaseCassEngTestCase, cls).tearDownClass()
         drop_table(TestIfNotExistsModel)
-        delete_keyspace(TestIfNotExistsModel.__keyspace__)
 
 
 class IfNotExistsInsertTests(BaseIfNotExistsTest):
@@ -139,7 +135,7 @@ class IfNotExistsModelTest(BaseIfNotExistsTest):
         self.assertTrue(isinstance(qs, TestIfNotExistsModel.__queryset__), type(qs))
 
     def test_batch_if_not_exists(self):
-        """ ensure 'IF NOT EXISTS' exists in statement when in batch """ 
+        """ ensure 'IF NOT EXISTS' exists in statement when in batch """
         with mock.patch.object(self.session, 'execute') as m:
             with BatchQuery() as b:
                 TestIfNotExistsModel.batch(b).if_not_exists().create(count=8)

--- a/cqlengine/tests/test_ifnotexists.py
+++ b/cqlengine/tests/test_ifnotexists.py
@@ -18,8 +18,6 @@ class TestIfNotExistsModel(Model):
 
 class TestIfNotExistsWithCounterModel(Model):
 
-    __keyspace__ = 'cqlengine_test_lwt'
-
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     likes   = columns.Counter()
 
@@ -39,23 +37,21 @@ class BaseIfNotExistsTest(BaseCassEngTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(BaseCassEngTestCase, cls).tearDownClass()
+        super(BaseIfNotExistsTest, cls).tearDownClass()
         drop_table(TestIfNotExistsModel)
-
 
 
 class BaseIfNotExistsWithCounterTest(BaseCassEngTestCase):
 
     @classmethod
     def setUpClass(cls):
-        create_keyspace(TestIfNotExistsModel.__keyspace__, replication_factor=1)
+        super(BaseIfNotExistsWithCounterTest, cls).setUpClass()
         sync_table(TestIfNotExistsWithCounterModel)
 
     @classmethod
     def tearDownClass(cls):
-        super(BaseCassEngTestCase, cls).tearDownClass()
+        super(BaseIfNotExistsWithCounterTest, cls).tearDownClass()
         drop_table(TestIfNotExistsWithCounterModel)
-        delete_keyspace(TestIfNotExistsModel.__keyspace__)
 
 
 class IfNotExistsInsertTests(BaseIfNotExistsTest):

--- a/cqlengine/tests/test_ifnotexists.py
+++ b/cqlengine/tests/test_ifnotexists.py
@@ -3,7 +3,7 @@ from cqlengine.management import sync_table, drop_table, create_keyspace, delete
 from cqlengine.tests.base import BaseCassEngTestCase
 from cqlengine.tests.base import PROTOCOL_VERSION
 from cqlengine.models import Model
-from cqlengine.exceptions import LWTException
+from cqlengine.exceptions import LWTException, IfNotExistsWithCounterColumn
 from cqlengine import columns, BatchQuery
 from uuid import uuid4
 import mock
@@ -14,6 +14,14 @@ class TestIfNotExistsModel(Model):
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
     text    = columns.Text(required=False)
+
+
+class TestIfNotExistsWithCounterModel(Model):
+
+    __keyspace__ = 'cqlengine_test_lwt'
+
+    id      = columns.UUID(primary_key=True, default=lambda:uuid4())
+    likes   = columns.Counter()
 
 
 class BaseIfNotExistsTest(BaseCassEngTestCase):
@@ -33,6 +41,21 @@ class BaseIfNotExistsTest(BaseCassEngTestCase):
     def tearDownClass(cls):
         super(BaseCassEngTestCase, cls).tearDownClass()
         drop_table(TestIfNotExistsModel)
+
+
+
+class BaseIfNotExistsWithCounterTest(BaseCassEngTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        create_keyspace(TestIfNotExistsModel.__keyspace__, replication_factor=1)
+        sync_table(TestIfNotExistsWithCounterModel)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(BaseCassEngTestCase, cls).tearDownClass()
+        drop_table(TestIfNotExistsWithCounterModel)
+        delete_keyspace(TestIfNotExistsModel.__keyspace__)
 
 
 class IfNotExistsInsertTests(BaseIfNotExistsTest):
@@ -170,3 +193,14 @@ class IfNotExistsInstanceTest(BaseIfNotExistsTest):
         self.assertNotIn("IF NOT EXIST", query)
 
 
+class IfNotExistWithCounterTest(BaseIfNotExistsWithCounterTest):
+
+    def test_instance_raise_exception(self):
+        """ make sure exception is raised when calling
+        if_not_exists on table with counter column
+        """
+        id = uuid4()
+        self.assertRaises(
+            IfNotExistsWithCounterColumn,
+            TestIfNotExistsWithCounterModel.if_not_exists
+            )

--- a/cqlengine/tests/test_load.py
+++ b/cqlengine/tests/test_load.py
@@ -8,7 +8,7 @@ import resource
 import gc
 
 class LoadTest(Model):
-    __keyspace__ = 'test'
+
     k = Integer(primary_key=True)
     v = Integer()
 

--- a/cqlengine/tests/test_timestamp.py
+++ b/cqlengine/tests/test_timestamp.py
@@ -12,7 +12,6 @@ from cqlengine.tests.base import BaseCassEngTestCase
 
 
 class TestTimestampModel(Model):
-    __keyspace__ = 'test'
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
 

--- a/cqlengine/tests/test_transaction.py
+++ b/cqlengine/tests/test_transaction.py
@@ -15,7 +15,6 @@ import six
 
 
 class TestTransactionModel(Model):
-    __keyspace__ = 'test'
     id = columns.UUID(primary_key=True, default=lambda:uuid4())
     count = columns.Integer()
     text = columns.Text(required=False)

--- a/cqlengine/tests/test_ttl.py
+++ b/cqlengine/tests/test_ttl.py
@@ -8,7 +8,6 @@ from cqlengine.connection import get_session
 
 
 class TestTTLModel(Model):
-    __keyspace__ = 'test'
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()
     text    = columns.Text(required=False)
@@ -28,7 +27,6 @@ class BaseTTLTest(BaseCassEngTestCase):
 
 
 class TestDefaultTTLModel(Model):
-    __keyspace__ = 'test'
     __default_ttl__ = 20
     id      = columns.UUID(primary_key=True, default=lambda:uuid4())
     count   = columns.Integer()


### PR DESCRIPTION
raise exception when calling if_not_exists for table with counter
columns. refer to https://github.com/cqlengine/cqlengine/issues/302 for
details.