### PR TITLE
raise exception when if_not_exists is not capable.

### DIFF
--- a/cqlengine/exceptions.py
+++ b/cqlengine/exceptions.py
@@ -5,3 +5,4 @@ class ValidationError(CQLEngineException): pass
 
 class UndefinedKeyspaceException(CQLEngineException): pass
 class LWTException(CQLEngineException): pass
+class IfNotExistsWithCounterColumn(CQLEngineException): pass

--- a/cqlengine/query.py
+++ b/cqlengine/query.py
@@ -7,7 +7,7 @@ from cqlengine.columns import Counter, List, Set
 
 from .connection import execute, NOT_SET
 
-from cqlengine.exceptions import CQLEngineException, ValidationError, LWTException
+from cqlengine.exceptions import CQLEngineException, ValidationError, LWTException, IfNotExistsWithCounterColumn
 from cqlengine.functions import Token, BaseQueryFunction, QueryValue, UnicodeMixin
 
 #CQL 3 reference:
@@ -784,6 +784,8 @@ class ModelQuerySet(AbstractQuerySet):
         return clone
 
     def if_not_exists(self):
+        if self.model._has_counter:
+            raise IfNotExistsWithCounterColumn('if_not_exists cannot be used with tables containing columns')
         clone = copy.deepcopy(self)
         clone._if_not_exists = True
         return clone

--- a/cqlengine/tests/test_ifnotexists.py
+++ b/cqlengine/tests/test_ifnotexists.py
@@ -63,10 +63,8 @@ class IfNotExistsInsertTests(BaseIfNotExistsTest):
         id = uuid4()
 
         TestIfNotExistsModel.create(id=id, count=8, text='123456789')
-        self.assertRaises(
-            LWTException,
-            TestIfNotExistsModel.if_not_exists().create, id=id, count=9, text='111111111111'
-            )
+        with self.assertRaises(LWTException):
+            TestIfNotExistsModel.if_not_exists().create(id=id, count=9, text='111111111111')
 
         q = TestIfNotExistsModel.objects(id=id)
         self.assertEqual(len(q), 1)
@@ -101,7 +99,8 @@ class IfNotExistsInsertTests(BaseIfNotExistsTest):
 
         b = BatchQuery()
         TestIfNotExistsModel.batch(b).if_not_exists().create(id=id, count=9, text='111111111111')
-        self.assertRaises(LWTException, b.execute)
+        with self.assertRaises(LWTException):
+            b.execute()
 
         q = TestIfNotExistsModel.objects(id=id)
         self.assertEqual(len(q), 1)
@@ -196,7 +195,6 @@ class IfNotExistWithCounterTest(BaseIfNotExistsWithCounterTest):
         if_not_exists on table with counter column
         """
         id = uuid4()
-        self.assertRaises(
-            IfNotExistsWithCounterColumn,
-            TestIfNotExistsWithCounterModel.if_not_exists
-            )
+        with self.assertRaises(IfNotExistsWithCounterColumn):
+            TestIfNotExistsWithCounterModel.if_not_exists()
+


### PR DESCRIPTION
raise exception when calling if_not_exists for table with counter
columns. refer to cqlengine#302 for details.