### PR TITLE
more static column related fixes

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -26,6 +26,7 @@ class BaseValueManager(object):
         self.column = column
         self.previous_value = deepcopy(value)
         self.value = value
+        self.explicit = False
 
     @property
     def deleted(self):

--- a/cqlengine/models.py
+++ b/cqlengine/models.py
@@ -336,6 +336,8 @@ class BaseModel(object):
             if value is not None or isinstance(column, columns.BaseContainerColumn):
                 value = column.to_python(value)
             value_mngr = column.value_manager(self, column, value)
+            if name in values:
+                value_mngr.explicit = True
             self._values[name] = value_mngr
 
         # a flag set by the deserializer to indicate
@@ -490,7 +492,10 @@ class BaseModel(object):
     def validate(self):
         """ Cleans and validates the field values """
         for name, col in self._columns.items():
-            val = col.validate(getattr(self, name))
+            v = getattr(self, name)
+            if not v and not self._values[name].explicit and col.has_default:
+                v = col.get_default()
+            val = col.validate(v)
             setattr(self, name, val)
 
     ### Let an instance be used like a dict of its columns keys/values

--- a/cqlengine/tests/columns/test_static_column.py
+++ b/cqlengine/tests/columns/test_static_column.py
@@ -11,7 +11,7 @@ from cqlengine.tests.base import CASSANDRA_VERSION, PROTOCOL_VERSION
 class TestStaticModel(Model):
 
     partition = columns.UUID(primary_key=True, default=uuid4)
-    cluster = columns.UUID(primary_key=True, default=uuid4)
+    cluster = columns.UUID(primary_key=True)
     static = columns.Text(static=True)
     text = columns.Text()
 
@@ -34,6 +34,7 @@ class TestStaticColumn(BaseCassEngTestCase):
     def test_mixed_updates(self):
         """ Tests that updates on both static and non-static columns work as intended """
         instance = TestStaticModel.create()
+        instance.cluster = uuid4()
         instance.static = "it's shared"
         instance.text = "some text"
         instance.save()
@@ -51,6 +52,7 @@ class TestStaticColumn(BaseCassEngTestCase):
         """ Tests that updates on static only column work as intended """
         instance = TestStaticModel.create()
         instance.static = "it's shared"
+        instance.cluster = uuid4()
         instance.text = "some text"
         instance.save()
 
@@ -60,3 +62,16 @@ class TestStaticColumn(BaseCassEngTestCase):
         actual = TestStaticModel.get(partition=u.partition)
         assert actual.static == "it's still shared"
 
+    @skipUnless(PROTOCOL_VERSION >= 2, "only runs against the cql3 protocol v2.0")
+    def test_static_with_null_cluster_key(self):
+        """ Tests that save/update/delete works for static column works when clustering key is null """
+        instance = TestStaticModel.create()
+        instance.static = "it's shared"
+        instance.cluster = None
+        instance.save()
+
+        u = TestStaticModel.get(partition=instance.partition)
+        u.static = "it's still shared"
+        u.update()
+        actual = TestStaticModel.get(partition=u.partition)
+        assert actual.static == "it's still shared"


### PR DESCRIPTION
There are two fixes for this pull request
1. When there is default value/function specified in model for a clustering key, it won't allow user to explicitly set this clustering key to None value. This fixes this issue. 
2. For model save/update/delete operation, we should not include clustering key if it is None.
