### PR TITLE
Addt'l FAQ for CQL3 Quoted Identifiers

### DIFF
--- a/docs/topics/faq.rst
+++ b/docs/topics/faq.rst
@@ -51,7 +51,10 @@ resolve to the statement with the lastest timestamp.
 Q: How do I reference a non-standard table/column?
 --------------------------------------------------
 
-A: Use double-quotes around the name of the table/column object just as you would in CQL.
+A: In CQL3, use double-quotes around the name of the table/column object just as you would in CQL.
+
+See `Apache Documentation
+<https://cassandra.apache.org/doc/cql3/CQL.html#identifiers>`_.
 
 With cqlengine:
 

--- a/docs/topics/faq.rst
+++ b/docs/topics/faq.rst
@@ -48,3 +48,21 @@ resolve to the statement with the lastest timestamp.
     assert MyModel.objects(id=1).first().count == 3
     assert MyModel.objects(id=1).first().text  == '111'
 
+Q: How do I reference a non-standard table/column?
+--------------------------------------------------
+
+A: Use double-quotes around the name of the table/column object just as you would in CQL.
+
+With cqlengine:
+
+.. code-block:: python
+    
+    from cqlengine.management import create_keyspace
+    create_keyspace('"1234567890"')
+
+With CQL3:
+
+.. code-block:: sql
+
+    CREATE KEYSPACE "1234567890" WITH REPLICATION = {...};
+


### PR DESCRIPTION
Added a FAQ for referencing non-lowercase, standard character table or column names.