### PR TITLE
Can now create containers with non-double floats

### DIFF
--- a/cqlengine/columns.py
+++ b/cqlengine/columns.py
@@ -532,7 +532,7 @@ class BaseContainerColumn(Column):
             self.value_col = self.value_type()
         else:
             self.value_col = value_type
-            self.value_type = self.value_col.__class__
+            self.value_type = value_type  # TODO self.value_col.__class__
 
         super(BaseContainerColumn, self).__init__(**kwargs)
 

--- a/cqlengine/tests/columns/test_container_columns.py
+++ b/cqlengine/tests/columns/test_container_columns.py
@@ -311,20 +311,31 @@ class TestListColumn(BaseCassEngTestCase):
         assert m3.int_list == []
 
     def test_float_list_is_float(self):
-        TestListModel.create(float_list=[1.0, 2.0, 3.0, 4.0])
+        floats = [0.0, 0.5, 1.0, 2.0, 3.0, 4.0]
+        TestListModel.create(float_list=floats)
         x = get_cluster()
         typestring = x.metadata.keyspaces[
             'cqlengine_test'].tables[
             'test_list_model'].columns['float_list'].typestring
         assert typestring == 'list<float>'
 
+        for model in TestListModel.objects:
+            if model.float_list:
+                assert model.float_list == floats
+
     def test_double_list_is_double(self):
-        TestListModel.create(double_list=[1.0, 2.0, 3.0, 4.0])
+        doubles = [0.0, 0.1, 0.5, 1.0, 2.0, 3.0, 4.0]
+        TestListModel.create(double_list=doubles)
         x = get_cluster()
         typestring = x.metadata.keyspaces[
             'cqlengine_test'].tables[
             'test_list_model'].columns['double_list'].typestring
         assert typestring == 'list<double>'
+
+        for model in TestListModel.objects:
+            if model.double_list:
+                assert model.double_list == doubles
+
 
 
 class TestMapModel(Model):


### PR DESCRIPTION
This should close #324 

Now, when creating a list of non-double precision floats, the type of the elements in the list are floats instead of doubles. 

All tests passed, but I'm still not sure this change doesn't have any side-effects. I have attempted to unit test the change, but I am unsure how to access the db_type variable of an element in the columns.List object from a Model object. If anyone knows how to find that information, that would speed up the creation of the tests significantly. Example of where I am currently stuck below (I have only found python types in the model object so far).

```python
 def test_float_list_is_float(self):
        m = TestListModel.create(float_list=[1.0, 2.0, 3.0, 4.0])
        # Now I need to make sure that float_list is represented as List<float>, rather than List<double>
```