### PR TITLE
Expose the existing data in case of a LWTException

### DIFF
--- a/cqlengine/exceptions.py
+++ b/cqlengine/exceptions.py
@@ -4,5 +4,18 @@ class ModelException(CQLEngineException): pass
 class ValidationError(CQLEngineException): pass
 
 class UndefinedKeyspaceException(CQLEngineException): pass
-class LWTException(CQLEngineException): pass
 class IfNotExistsWithCounterColumn(CQLEngineException): pass
+
+class LWTException(CQLEngineException):
+
+    def __init__(self, existing):
+        """Lightweight transaction exception.
+
+        This exception will be raised when a write using an `IF` clause could
+        not be applied due to existing data violating the condition. The
+        existing data is available through the `existing` attribute.
+
+        :param existing: The current state of the data which prevented the write.
+        """
+        super(LWTException, self).__init__(self)
+        self.existing = existing

--- a/cqlengine/query.py
+++ b/cqlengine/query.py
@@ -31,7 +31,7 @@ def check_applied(result):
     applied to database.
     """
     if result and '[applied]' in result[0] and result[0]['[applied]'] == False:
-        raise LWTException('')
+        raise LWTException(result[0])
 
 
 class AbstractQueryableColumn(UnicodeMixin):

--- a/cqlengine/tests/test_ifnotexists.py
+++ b/cqlengine/tests/test_ifnotexists.py
@@ -63,8 +63,15 @@ class IfNotExistsInsertTests(BaseIfNotExistsTest):
         id = uuid4()
 
         TestIfNotExistsModel.create(id=id, count=8, text='123456789')
-        with self.assertRaises(LWTException):
+        with self.assertRaises(LWTException) as assertion:
             TestIfNotExistsModel.if_not_exists().create(id=id, count=9, text='111111111111')
+
+        self.assertEquals(assertion.exception.existing, {
+            'count': 8,
+            'id': id,
+            'text': '123456789',
+            '[applied]': False,
+        })
 
         q = TestIfNotExistsModel.objects(id=id)
         self.assertEqual(len(q), 1)
@@ -99,8 +106,15 @@ class IfNotExistsInsertTests(BaseIfNotExistsTest):
 
         b = BatchQuery()
         TestIfNotExistsModel.batch(b).if_not_exists().create(id=id, count=9, text='111111111111')
-        with self.assertRaises(LWTException):
+        with self.assertRaises(LWTException) as assertion:
             b.execute()
+
+        self.assertEquals(assertion.exception.existing, {
+            'count': 8,
+            'id': id,
+            'text': '123456789',
+            '[applied]': False,
+        })
 
         q = TestIfNotExistsModel.objects(id=id)
         self.assertEqual(len(q), 1)
@@ -197,4 +211,3 @@ class IfNotExistWithCounterTest(BaseIfNotExistsWithCounterTest):
         id = uuid4()
         with self.assertRaises(IfNotExistsWithCounterColumn):
             TestIfNotExistsWithCounterModel.if_not_exists()
-


### PR DESCRIPTION
Exposing the existing data which caused a failure of the `IF` condition
is very useful to an application. The documentation already implied at
this being available but it did not seem to be implemented yet.