### PR TITLE
docs: Fix a few typos

### DIFF
--- a/cqlengine/models.py
+++ b/cqlengine/models.py
@@ -608,7 +608,7 @@ class BaseModel(object):
         for k, v in values.items():
             col = self._columns.get(k)
 
-            # check for nonexistant columns
+            # check for nonexistent columns
             if col is None:
                 raise ValidationError("{}.{} has no column named: {}".format(self.__module__, self.__class__.__name__, k))
 

--- a/cqlengine/query.py
+++ b/cqlengine/query.py
@@ -525,7 +525,7 @@ class AbstractQuerySet(object):
         Returns a single instance matching this query, optionally with additional filter kwargs.
 
         A DoesNotExistError will be raised if there are no rows matching the query
-        A MultipleObjectsFoundError will be raised if there is more than one row matching the queyr
+        A MultipleObjectsFoundError will be raised if there is more than one row matching the query
         """
         if args or kwargs:
             return self.filter(*args, **kwargs).get()
@@ -801,7 +801,7 @@ class ModelQuerySet(AbstractQuerySet):
         for name, val in values.items():
             col_name, col_op = self._parse_filter_arg(name)
             col = self.model._columns.get(col_name)
-            # check for nonexistant columns
+            # check for nonexistent columns
             if col is None:
                 raise ValidationError("{}.{} has no column named: {}".format(self.__module__, self.model.__name__, col_name))
             # check for primary key update attempts

--- a/cqlengine/tests/columns/test_container_columns.py
+++ b/cqlengine/tests/columns/test_container_columns.py
@@ -114,7 +114,7 @@ class TestSetColumn(BaseCassEngTestCase):
             TestSetModel.create(text_set={str(uuid4()) for i in range(65536)})
 
     def test_partial_updates(self):
-        """ Tests that partial udpates work as expected """
+        """ Tests that partial updates work as expected """
         m1 = TestSetModel.create(int_set={1, 2, 3, 4})
 
         m1.int_set.add(5)
@@ -225,7 +225,7 @@ class TestListColumn(BaseCassEngTestCase):
             TestListModel.create(text_list=[str(uuid4()) for i in range(65536)])
 
     def test_partial_updates(self):
-        """ Tests that partial udpates work as expected """
+        """ Tests that partial updates work as expected """
         final = list(range(10))
         initial = final[3:7]
         m1 = TestListModel.create(int_list=initial)
@@ -394,7 +394,7 @@ class TestMapColumn(BaseCassEngTestCase):
             TestMapModel.create(text_map={str(uuid4()): i for i in range(65536)})
 
     def test_partial_updates(self):
-        """ Tests that partial udpates work as expected """
+        """ Tests that partial updates work as expected """
         now = datetime.now()
         #derez it a bit
         now = datetime(*now.timetuple()[:-3])

--- a/cqlengine/tests/management/test_management.py
+++ b/cqlengine/tests/management/test_management.py
@@ -202,7 +202,7 @@ class TablePropertiesTests(BaseCassEngTestCase):
         if CASSANDRA_VERSION == 20:
              expected['index_interval'] = 94207
 
-        # these featuers removed in cassandra 2.1
+        # these features removed in cassandra 2.1
         if CASSANDRA_VERSION <= 20:
             expected['caching'] = CACHING_NONE
             expected['replicate_on_write'] = True

--- a/cqlengine/tests/model/test_class_construction.py
+++ b/cqlengine/tests/model/test_class_construction.py
@@ -24,7 +24,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
             id  = columns.UUID(primary_key=True, default=lambda:uuid4())
             text = columns.Text()
 
-        #check class attibutes
+        #check class attributes
         self.assertHasAttr(TestModel, '_columns')
         self.assertHasAttr(TestModel, 'id')
         self.assertHasAttr(TestModel, 'text')

--- a/cqlengine/tests/model/test_updates.py
+++ b/cqlengine/tests/model/test_updates.py
@@ -30,7 +30,7 @@ class ModelUpdateTests(BaseCassEngTestCase):
         drop_table(TestUpdateModel)
 
     def test_update_model(self):
-        """ tests calling udpate on models with no values passed in """
+        """ tests calling update on models with no values passed in """
         m0 = TestUpdateModel.create(count=5, text='monkey')
 
         # independently save over a new count value, unknown to original instance

--- a/cqlengine/tests/query/test_named.py
+++ b/cqlengine/tests/query/test_named.py
@@ -33,7 +33,7 @@ class TestQuerySetOperation(BaseCassEngTestCase):
         assert op.value == 1
 
     def test_query_expression_parsing(self):
-        """ Tests that query experessions are evaluated properly """
+        """ Tests that query expressions are evaluated properly """
         query1 = self.table.filter(self.table.column('test_id') == 5)
         assert len(query1._where) == 1
 

--- a/cqlengine/tests/query/test_queryset.py
+++ b/cqlengine/tests/query/test_queryset.py
@@ -90,7 +90,7 @@ class TestQuerySetOperation(BaseCassEngTestCase):
         assert op.value == 1
 
     def test_query_expression_parsing(self):
-        """ Tests that query experessions are evaluated properly """
+        """ Tests that query expressions are evaluated properly """
         query1 = TestModel.filter(TestModel.test_id == 5)
         assert len(query1._where) == 1
 
@@ -109,14 +109,14 @@ class TestQuerySetOperation(BaseCassEngTestCase):
 
     def test_using_invalid_column_names_in_filter_kwargs_raises_error(self):
         """
-        Tests that using invalid or nonexistant column names for filter args raises an error
+        Tests that using invalid or nonexistent column names for filter args raises an error
         """
         with self.assertRaises(query.QueryException):
             TestModel.objects(nonsense=5)
 
-    def test_using_nonexistant_column_names_in_query_args_raises_error(self):
+    def test_using_nonexistent_column_names_in_query_args_raises_error(self):
         """
-        Tests that using invalid or nonexistant columns for query args raises an error
+        Tests that using invalid or nonexistent columns for query args raises an error
         """
         with self.assertRaises(AttributeError):
             TestModel.objects(TestModel.nonsense == 5)
@@ -171,7 +171,7 @@ class TestQuerySetOperation(BaseCassEngTestCase):
         Tests that trying to add fields to either only or defer, or doing so more than once fails
         """
 
-    def test_defining_only_or_defer_on_nonexistant_fields_fails(self):
+    def test_defining_only_or_defer_on_nonexistent_fields_fails(self):
         """
         Tests that setting only or defer fields that don't exist raises an exception
         """

--- a/cqlengine/tests/query/test_updates.py
+++ b/cqlengine/tests/query/test_updates.py
@@ -31,7 +31,7 @@ class QueryUpdateTests(BaseCassEngTestCase):
         drop_table(TestQueryUpdateModel)
 
     def test_update_values(self):
-        """ tests calling udpate on a queryset """
+        """ tests calling update on a queryset """
         partition = uuid4()
         for i in range(5):
             TestQueryUpdateModel.create(partition=partition, cluster=i, count=i, text=str(i))
@@ -51,7 +51,7 @@ class QueryUpdateTests(BaseCassEngTestCase):
             assert row.text == str(i)
 
     def test_update_values_validation(self):
-        """ tests calling udpate on models with values passed in """
+        """ tests calling update on models with values passed in """
         partition = uuid4()
         for i in range(5):
             TestQueryUpdateModel.create(partition=partition, cluster=i, count=i, text=str(i))
@@ -205,7 +205,7 @@ class QueryUpdateTests(BaseCassEngTestCase):
 
         This test fails because of a bug in the cql python library not
         converting None to null (and the cql library is no longer in active
-        developement).
+        development).
         """
         # partition = uuid4()
         # cluster = 1

--- a/docs/topics/development.rst
+++ b/docs/topics/development.rst
@@ -12,7 +12,7 @@ Python versions:
 - 2.7
 - 3.4
 
-Cassandra vesions:
+Cassandra versions:
 
 - 1.2 (protocol_version 1)
 - 2.0 (protocol_version 2)
@@ -28,7 +28,7 @@ Please see the contributing guidelines: https://github.com/cqlengine/cqlengine/b
 Testing Locally
 =================
 
-Before testing, you'll need to set an environment variable to the version of Cassandra that's being tested.  The version cooresponds to the <Major><Minor> release, so for example if you're testing against Cassandra 2.1, you'd set the following:
+Before testing, you'll need to set an environment variable to the version of Cassandra that's being tested.  The version corresponds to the <Major><Minor> release, so for example if you're testing against Cassandra 2.1, you'd set the following:
 
 .. code-block:: bash
 

--- a/docs/topics/queryset.rst
+++ b/docs/topics/queryset.rst
@@ -208,7 +208,7 @@ TimeUUID Functions
 Token Function
 ==============
 
-    Token functon may be used only on special, virtual column pk__token, representing token of partition key (it also works for composite partition keys).
+    Token function may be used only on special, virtual column pk__token, representing token of partition key (it also works for composite partition keys).
     Cassandra orders returned items by value of partition key token, so using cqlengine.Token we can easy paginate through all table rows.
 
     See http://cassandra.apache.org/doc/cql3/CQL.html#tokenFun


### PR DESCRIPTION
There are small typos in:
- cqlengine/models.py
- cqlengine/query.py
- cqlengine/tests/columns/test_container_columns.py
- cqlengine/tests/management/test_management.py
- cqlengine/tests/model/test_class_construction.py
- cqlengine/tests/model/test_updates.py
- cqlengine/tests/query/test_named.py
- cqlengine/tests/query/test_queryset.py
- cqlengine/tests/query/test_updates.py
- docs/topics/development.rst
- docs/topics/queryset.rst

Fixes:
- Should read `updates` rather than `udpates`.
- Should read `nonexistent` rather than `nonexistant`.
- Should read `update` rather than `udpate`.
- Should read `expressions` rather than `experessions`.
- Should read `versions` rather than `vesions`.
- Should read `query` rather than `queyr`.
- Should read `function` rather than `functon`.
- Should read `features` rather than `featuers`.
- Should read `development` rather than `developement`.
- Should read `corresponds` rather than `cooresponds`.
- Should read `attributes` rather than `attibutes`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md